### PR TITLE
Implement `create_federated_identity_credential` in `tfe` configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Before using this module, ensure you have the following prerequisites:
 | TFC_AZURE_PROVIDER_AUTH | true/false if authenticating using OIDC | When bootstrapping with the provided bootstrap folder, set to true | 
 | TFC_AZURE_RUN_CLIENT_ID | Client ID of the identity to execute with |
 
-### Variables
-
-| Name | Description | Comment |
-| ---- | ----------- | ------- |
-TFE_ORGANIZATION | The name of the Terraform Cloud organization | Used when automatically creating Federated Identity Credential Config for tfe. This must exist alongside env var TFE_ORGANIZATION
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Before using this module, ensure you have the following prerequisites:
 | TFC_AZURE_PROVIDER_AUTH | true/false if authenticating using OIDC | When bootstrapping with the provided bootstrap folder, set to true | 
 | TFC_AZURE_RUN_CLIENT_ID | Client ID of the identity to execute with |
 
+### Variables
+
+| Name | Description | Comment |
+| ---- | ----------- | ------- |
+TFE_ORGANIZATION | The name of the Terraform Cloud organization | Used when automatically creating Federated Identity Credential Config for tfe. This must exist alongside env var TFE_ORGANIZATION
+
 
 ## Usage
 

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -22,7 +22,7 @@ locals {
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
   for_each              = try(var.tfe.create_federated_identity_credential, false) ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
-  ddisplay_name         = "ficc-station-proj-id-${random_id.workload.hex}-tfc-${each.value.phase}"
+  display_name          = "ficc-station-proj-id-${random_id.workload.hex}-tfc-${each.value.phase}"
   description           = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://app.terraform.io"

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -11,12 +11,10 @@ resource "azuread_application_federated_identity_credential" "oidc" {
 locals {
   oidc_tfe = {
     plan = {
-      display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (plan phase)"
-      subject      = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:plan"
+      phase = "plan"
     },
     apply = {
-      display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (apply phase)"
-      subject      = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:apply"
+      phase = "apply"
     },
   }
 }
@@ -24,8 +22,8 @@ locals {
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
   for_each              = var.tfe.create_federated_identity_credential ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
-  display_name          = each.value.display_name
+  display_name          = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://app.terraform.io"
-  subject               = each.value.subject
+  subject               = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
 }

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -7,3 +7,25 @@ resource "azuread_application_federated_identity_credential" "oidc" {
   issuer                = each.value.issuer
   subject               = each.value.subject
 }
+
+locals {
+  oidc_tfe = {
+    plan = {
+      display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (plan phase)"
+      subject      = "organization:${var.TFE_ORGANIZATION}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:plan"
+    },
+    apply = {
+      display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (apply phase)"
+      subject      = "organization:${var.TFE_ORGANIZATION}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:apply"
+    },
+  }
+}
+
+resource "azuread_application_federated_identity_credential" "oidc-tfe" {
+  for_each              = var.tfe.create_federated_identity_credential ? [local.oidc_tfe] : [0]
+  application_object_id = azuread_application.workload.object_id
+  display_name          = each.value.display_name
+  audiences             = ["api://AzureADTokenExchange"]
+  issuer                = "https://app.terraform.io"
+  subject               = each.value.subject
+}

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
-  for_each              = var.tfe.create_federated_identity_credential ? [local.oidc_tfe] : [0]
+  for_each              = var.tfe.create_federated_identity_credential ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
   display_name          = each.value.display_name
   audiences             = ["api://AzureADTokenExchange"]

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
-  for_each              = var.tfe.create_federated_identity_credential ? local.oidc_tfe : {}
+  for_each              = try(var.tfe.create_federated_identity_credential, false) ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
   display_name          = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
   audiences             = ["api://AzureADTokenExchange"]

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -22,7 +22,8 @@ locals {
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
   for_each              = try(var.tfe.create_federated_identity_credential, false) ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
-  display_name          = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
+  ddisplay_name         = "ficc-station-proj-id-${random_id.workload.hex}-tfc-${each.value.phase}"
+  description           = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://app.terraform.io"
   subject               = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -12,11 +12,11 @@ locals {
   oidc_tfe = {
     plan = {
       display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (plan phase)"
-      subject      = "organization:${var.TFE_ORGANIZATION}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:plan"
+      subject      = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:plan"
     },
     apply = {
       display_name = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (apply phase)"
-      subject      = "organization:${var.TFE_ORGANIZATION}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:apply"
+      subject      = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:apply"
     },
   }
 }

--- a/tests/tfe/terraform_cloud.tf
+++ b/tests/tfe/terraform_cloud.tf
@@ -63,6 +63,7 @@ module "station-tfe" {
   #  }
 
   tfe = {
+    organization_name     = "managed-devops"
     project_name          = local.tfe_projects.tfe_tests.project_name
     workspace_name        = "tfe-${each.value.environment_name}"
     workspace_description = "This workspace is for testing Station's TFE integration"
@@ -98,6 +99,6 @@ module "station-bitbucket" {
 }
 
 variable "VCS_OAUTH_TOKEN_ID" {
-  type = string
+  type      = string
   sensitive = true
 }

--- a/tests/tfe/terraform_cloud.tf
+++ b/tests/tfe/terraform_cloud.tf
@@ -71,6 +71,7 @@ module "station-tfe" {
       identifier                 = "kimfy/tfe-testing"
       github_app_installation_id = var.github_app_installation_id
     }
+    create_federated_identity_credential = true
   }
 
   tags = {


### PR DESCRIPTION
This pull request enables automatic OIDC set up with the workload service principal and the Station generated Terraform Cloud workspace (plan and apply phases). In practice it enables you to immediately start writing Terraform code in the repository you are linking to and Terraform Cloud will deploy that infrastructure.

Resolves #20 