### PR TITLE
Populate TFC workspace with variables required for Azure auth + some extras

### DIFF
--- a/tfe.tf
+++ b/tfe.tf
@@ -4,13 +4,19 @@ module "station-tfe" {
   project_name          = var.tfe.project_name
   workspace_name        = var.tfe.workspace_name
   workspace_description = var.tfe.workspace_description
+  vcs_repo              = try(var.tfe.vcs_repo, null)
   env_vars = merge(try(var.tfe.env_vars, {}), {
-    station_id = {
+    # Terraform variables are prefixed with TF_VAR_ to suppress TFC Runner warning of unused variables.
+    TF_VAR_station_id = {
       value       = random_id.workload.hex
       category    = "terraform"
       description = "Station ID"
     },
-
+    TF_VAR_workload_resource_group_name = {
+      value       = azurerm_resource_group.workload.name
+      category    = "terraform"
+      description = "Name of the resource group created by Station"
+    },
     # DOCS: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud
     TFC_AZURE_PROVIDER_AUTH = {
       value       = true
@@ -33,5 +39,4 @@ module "station-tfe" {
       description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
     },
   })
-  vcs_repo = try(var.tfe.vcs_repo, null)
 }

--- a/tfe.tf
+++ b/tfe.tf
@@ -9,17 +9,17 @@ module "station-tfe" {
     # Terraform variables are prefixed with TF_VAR_ to suppress TFC Runner warning of unused variables.
     TF_VAR_station_id = {
       value       = random_id.workload.hex
-      category    = "terraform"
+      category    = "env"
       description = "Station ID"
     },
     TF_VAR_workload_resource_group_name = {
       value       = azurerm_resource_group.workload.name
-      category    = "terraform"
+      category    = "env"
       description = "Name of the resource group created by Station"
     },
     TF_VAR_environment_name = {
       value       = var.environment_name
-      category    = "terraform"
+      category    = "env"
       description = "Name of the current deployment environment. Often dev/test/stage/prod."
     },
     # DOCS: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud

--- a/tfe.tf
+++ b/tfe.tf
@@ -17,6 +17,11 @@ module "station-tfe" {
       category    = "terraform"
       description = "Name of the resource group created by Station"
     },
+    TF_VAR_environment_name = {
+      value       = var.environment_name
+      category    = "terraform"
+      description = "Name of the current deployment environment. Often dev/test/stage/prod."
+    },
     # DOCS: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud
     TFC_AZURE_PROVIDER_AUTH = {
       value       = true

--- a/tfe.tf
+++ b/tfe.tf
@@ -10,6 +10,28 @@ module "station-tfe" {
       category    = "terraform"
       description = "Station ID"
     },
+
+    # DOCS: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud
+    TFC_AZURE_PROVIDER_AUTH = {
+      value       = true
+      category    = "env"
+      description = "Is true when using dynamic credentials to authenticate to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
+    },
+    TFC_AZURE_RUN_CLIENT_ID = {
+      value       = azuread_service_principal.workload.application_id
+      category    = "env"
+      description = "The client ID for the Service Principal / Application used when authenticating to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
+    },
+    ARM_SUBSCRIPTION_ID = {
+      value       = data.azurerm_client_config.current.subscription_id
+      category    = "env"
+      description = "The Subscription ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+    },
+    ARM_TENANT_ID = {
+      value       = data.azurerm_client_config.current.tenant_id
+      category    = "env"
+      description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+    },
   })
   vcs_repo = try(var.tfe.vcs_repo, null)
 }


### PR DESCRIPTION
This pull request implementes all the variables in #22  as environment variables. This makes using them optional in the workspace. Terraform env vars that start with TF_VAR_ do not need to be specified in a variables.tf file if you do not intend on using them.

The workspace IaC do however need to include a variables {} block for every variable they intend to use AFAIK.