### PR TITLE
Terraform Cloud defaults 

### DIFF
--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -20,11 +20,11 @@ locals {
 }
 
 resource "azuread_application_federated_identity_credential" "oidc-tfe" {
-  for_each              = try(var.tfe.create_federated_identity_credential, false) ? local.oidc_tfe : {}
+  for_each              = try(var.tfe.create_federated_identity_credential, true) ? local.oidc_tfe : {}
   application_object_id = azuread_application.workload.object_id
   display_name          = "ficc-station-proj-id-${random_id.workload.hex}-tfc-${each.value.phase}"
   description           = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
   audiences             = ["api://AzureADTokenExchange"]
   issuer                = "https://app.terraform.io"
-  subject               = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
+  subject               = "organization:${module.station-tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
 }

--- a/hashicorp/tfe/outputs.tf
+++ b/hashicorp/tfe/outputs.tf
@@ -5,3 +5,8 @@ output "project_name" {
 output "workspace" {
   value = tfe_workspace.workload
 }
+
+output "organization_name" {
+  value = data.tfe_organization.this.name
+}
+


### PR DESCRIPTION
- create_federated_identity_credential now true by default
- Removed organization_name dependency from oidc generation

This PR fixes issue #33 