### PR TITLE
Implement group membership

### DIFF
--- a/group/group.tf
+++ b/group/group.tf
@@ -3,7 +3,6 @@ resource "azuread_group" "group" {
   owners           = var.owners
   security_enabled = can(var.settings.security_enabled) != null ? var.settings.security_enabled : true
   types            = try(var.settings.types, null) != null ? var.settings.types : []
-  members          = try(var.settings.members, null)
 
   dynamic "dynamic_membership" {
     for_each = try(var.settings.dynamic_membership, {})
@@ -13,5 +12,11 @@ resource "azuread_group" "group" {
       rule    = dynamic_membership.value.rule
     }
   }
+}
+
+resource "azuread_group_member" "members" {
+  for_each         = try(var.settings.members, null) != null ? toset(var.settings.members) : []
+  group_object_id  = azuread_group.group.object_id
+  member_object_id = each.key
 }
 

--- a/group/group.tf
+++ b/group/group.tf
@@ -1,7 +1,7 @@
 resource "azuread_group" "group" {
   display_name     = var.settings.display_name
   owners           = var.owners
-  security_enabled = can(var.settings.security_enabled) != null ? var.settings.security_enabled : true
+  security_enabled = try(var.settings.security_enabled, true)
   types            = try(var.settings.types, null) != null ? var.settings.types : []
 
   dynamic "dynamic_membership" {

--- a/group/outputs.tf
+++ b/group/outputs.tf
@@ -1,3 +1,12 @@
 output "group" {
   value = azuread_group.group
 }
+
+output "display_name" {
+  value = azuread_group.group.display_name 
+}
+
+output "object_id" {
+  value = azuread_group.group.object_id 
+}
+

--- a/group_membership.tf
+++ b/group_membership.tf
@@ -1,0 +1,6 @@
+resource "azuread_group_member" "workload" {
+  for_each         = toset(var.group_membership)
+  group_object_id  = each.key
+  member_object_id = azuread_service_principal.workload.object_id
+}
+

--- a/groups.tf
+++ b/groups.tf
@@ -2,6 +2,6 @@ module "ad_groups" {
   for_each = var.groups
   source   = "./group"
   settings = each.value.settings
-  owners   = try(each.value.settings.add_workload_sp_to_owners, true) ? concat(each.value.settings.owners, [azuread_service_principal.workload.object_id]) : each.value.settings.owners
+  owners   = try(each.value.settings.add_workload_sp_to_owners, true) ? concat(try(each.value.settings.owners, []), [azuread_service_principal.workload.object_id]) : each.value.settings.owners
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,10 @@ output "applications" {
 }
 
 output "groups" {
-  value = module.ad_groups
+  value = { for k, v in module.ad_groups : k => {
+    display_name = v.group.display_name
+    object_id    = v.group.object_id
+  } }
 }
 
 output "user_assigned_identities" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,10 +23,7 @@ output "applications" {
 }
 
 output "groups" {
-  value = { for k, v in module.ad_groups : k => {
-    display_name = v.group.display_name
-    object_id    = v.group.object_id
-  } }
+  value = module.ad_groups
 }
 
 output "user_assigned_identities" {

--- a/tfe.tf
+++ b/tfe.tf
@@ -55,7 +55,7 @@ module "station-tfe" {
     },
     },
     # Optionals
-    can(var.tfe.module_outputs_to_workspace_var.groups) ? {
+    var.tfe.module_outputs_to_workspace_var.groups ? {
       groups = {
         value = replace(jsonencode({ for k, v in module.ad_groups : k => {
           display_name = v.group.display_name
@@ -67,7 +67,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    can(var.tfe.module_outputs_to_workspace_var.applications) ? {
+    var.tfe.module_outputs_to_workspace_var.applications ? {
       applications = {
         value = replace(jsonencode({ for k, v in module.applications : k => {
           application_id = v.application.application_id
@@ -79,7 +79,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    can(var.tfe.module_outputs_to_workspace_var.user_assigned_identities) ? {
+    var.tfe.module_outputs_to_workspace_var.user_assigned_identities ? {
       user_assigned_identities = {
         value = replace(jsonencode({ for k, v in module.user_assigned_identities : k => {
           id           = v.identities.id

--- a/tfe.tf
+++ b/tfe.tf
@@ -55,7 +55,7 @@ module "station-tfe" {
     },
     },
     # Optionals
-    var.tfe.module_outputs_to_workspace_var.groups ? {
+    try(var.tfe.module_outputs_to_workspace_var.groups == true, false) ? {
       groups = {
         value = replace(jsonencode({ for k, v in module.ad_groups : k => {
           display_name = v.group.display_name
@@ -67,7 +67,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    var.tfe.module_outputs_to_workspace_var.applications ? {
+    try(var.tfe.module_outputs_to_workspace_var.applications == true, false) ? {
       applications = {
         value = replace(jsonencode({ for k, v in module.applications : k => {
           application_id = v.application.application_id
@@ -79,7 +79,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    var.tfe.module_outputs_to_workspace_var.user_assigned_identities ? {
+    try(var.tfe.module_outputs_to_workspace_var.user_assigned_identities == true, false) ? {
       user_assigned_identities = {
         value = replace(jsonencode({ for k, v in module.user_assigned_identities : k => {
           id           = v.identities.id

--- a/tfe.tf
+++ b/tfe.tf
@@ -55,7 +55,7 @@ module "station-tfe" {
     },
     },
     # Optionals
-    try(var.tfe.module_outputs_to_workspace_var.groups, false) ? {
+    can(var.tfe.module_outputs_to_workspace_var.groups) ? {
       groups = {
         value = replace(jsonencode({ for k, v in module.ad_groups : k => {
           display_name = v.group.display_name
@@ -67,7 +67,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    try(var.tfe.module_outputs_to_workspace_var.applications, false) ? {
+    can(var.tfe.module_outputs_to_workspace_var.applications) ? {
       applications = {
         value = replace(jsonencode({ for k, v in module.applications : k => {
           application_id = v.application.application_id
@@ -79,7 +79,7 @@ module "station-tfe" {
         sensitive   = false
       }
     } : {},
-    try(var.tfe.module_outputs_to_workspace_var.user_assigned_identities, false) ? {
+    can(var.tfe.module_outputs_to_workspace_var.user_assigned_identities) ? {
       user_assigned_identities = {
         value = replace(jsonencode({ for k, v in module.user_assigned_identities : k => {
           id           = v.identities.id

--- a/variables.tf
+++ b/variables.tf
@@ -51,10 +51,10 @@ variable "tfe" {
   description = "Terraform Cloud configuration. See submodule ./hashicorp/tfe/variables.tf for settings"
   default     = null
   type = object({
-    organization_name     = string
-    project_name          = string
-    workspace_name        = string
-    workspace_description = string
+    organization_name                    = string
+    project_name                         = string
+    workspace_name                       = string
+    workspace_description                = string
     create_federated_identity_credential = optional(bool)
     vcs_repo = optional(object({
       identifier                 = string
@@ -79,3 +79,8 @@ variable "tfe" {
   })
 }
 
+variable "group_membership" {
+  type        = list(string)
+  description = "List of group object ids the workload identity should be member of"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,11 @@ variable "tfe" {
       hcl         = bool
       sensitive   = bool
     })))
+    module_outputs_to_workspace_var = optional(object({
+      groups                   = optional(bool)
+      applications             = optional(bool)
+      user_assigned_identities = optional(bool)
+    }))
   })
 }
 


### PR DESCRIPTION
Delegate group membership to Station.

Use cases:
Say you have a workload that creates a group, this group is assigned a permission on a resource in this workload. Later, with another workload you may want to add a principal to the group, but don't want your original workload to depend on another. Since the principal that runs Station Deployments ideally should have Global Administrator, this approach makes more sense than managing group membership singlehandedly from the workload that creates the group.

Visualized:
module x => create group
module y => add group member to group from module x

Possible pitfalls
- Destroying the module which provisions the group causes dependent workloads to fail (group will not exist)


Edit:
This PR implements the functionality with the following
- Station gets a new variable `group_membership` with type `list(string)`. The list will contain group object ids the workload identity is added to.
- `group_membership.tf`: Loops over variable and adds workload identity to group
- Sub-module groups splits `azuread_group.members`  into a separate `azuread_group_member` resource
- Improves sub-module group output with `display_name` and `object_id`

