### PR TITLE
Use managed identity instead of application with service principal

### DIFF
--- a/app_role_assignment.tf
+++ b/app_role_assignment.tf
@@ -8,7 +8,7 @@ resource "azuread_service_principal" "msgraph" {
 # Assign the workload identity the `Application.ReadWrite.OwnedBy` role so it can interact with the applications they own however they desire
 resource "azuread_app_role_assignment" "app_workload_roles" {
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["Application.ReadWrite.OwnedBy"]
-  principal_object_id = azuread_service_principal.workload.object_id
+  principal_object_id = module.user_assigned_identity.principal_id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 

--- a/application.tf
+++ b/application.tf
@@ -1,5 +1,0 @@
-resource "azuread_application" "workload" {
-  display_name = "app-${random_id.workload.hex}-${var.environment_name}"
-  notes        = "This application was created by Station (https://github.com/kimfy/station.git)"
-}
-

--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -1,11 +1,11 @@
-resource "azuread_application_federated_identity_credential" "oidc" {
-  for_each              = var.federated_identity_credential_config
-  application_object_id = azuread_application.workload.object_id
-  display_name          = each.value.display_name
-  description           = each.value.description
-  audiences             = each.value.audiences
-  issuer                = each.value.issuer
-  subject               = each.value.subject
+resource "azurerm_federated_identity_credential" "oidc" {
+  for_each            = var.federated_identity_credential_config
+  resource_group_name = azurerm_resource_group.workload.name
+  parent_id           = module.user_assigned_identity.id
+  name                = each.value.display_name
+  audience            = each.value.audiences
+  issuer              = each.value.issuer
+  subject             = each.value.subject
 }
 
 locals {
@@ -19,12 +19,13 @@ locals {
   }
 }
 
-resource "azuread_application_federated_identity_credential" "oidc-tfe" {
-  for_each              = can(var.tfe.create_federated_identity_credential) ? local.oidc_tfe : {}
-  application_object_id = azuread_application.workload.object_id
-  display_name          = "ficc-station-proj-id-${random_id.workload.hex}-tfc-${each.value.phase}"
-  description           = "Terraform Cloud OIDC Station Project ${random_id.workload.hex} (${each.value.phase} phase)"
-  audiences             = ["api://AzureADTokenExchange"]
-  issuer                = "https://app.terraform.io"
-  subject               = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
+resource "azurerm_federated_identity_credential" "oidc-tfe" {
+  for_each            = can(var.tfe.create_federated_identity_credential) ? local.oidc_tfe : {}
+  resource_group_name = azurerm_resource_group.workload.name
+  parent_id           = module.user_assigned_identity.id
+  name                = "terraform-cloud-run-phase-${each.value.phase}"
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://app.terraform.io"
+  subject             = "organization:${var.tfe.organization_name}:project:${var.tfe.project_name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
 }
+

--- a/applications.tf
+++ b/applications.tf
@@ -5,7 +5,7 @@ module "applications" {
   # Add workload identity service principal to the list of owners
   owners = concat(
     each.value.owners == null ? [] : each.value.owners,
-    [azuread_service_principal.workload.object_id]
+    [module.user_assigned_identity.principal_id]
   )
 }
 

--- a/group_membership.tf
+++ b/group_membership.tf
@@ -1,6 +1,6 @@
 resource "azuread_group_member" "workload" {
   for_each         = toset(var.group_membership)
   group_object_id  = each.key
-  member_object_id = azuread_service_principal.workload.object_id
+  member_object_id = module.user_assigned_identity.principal_id
 }
 

--- a/groups.tf
+++ b/groups.tf
@@ -4,6 +4,6 @@ module "ad_groups" {
   azuread_group = each.value
   owners = concat(
     each.value.owners == null ? [] : each.value.owners,
-    [azuread_service_principal.workload.object_id]
+    [module.user_assigned_identity.principal_id]
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "client_id" {
-  value = azuread_service_principal.workload.application_id
+  value = module.user_assigned_identity.client_id
 }
 
 output "workload_service_principal_object_id" {
-  value = azuread_service_principal.workload.object_id
+  value = module.user_assigned_identity.principal_id
 }
 
 output "tenant_id" {

--- a/role_assignment.tf
+++ b/role_assignment.tf
@@ -1,7 +1,7 @@
 # Assign the workload service principal a role on the workload resource group
 resource "azurerm_role_assignment" "rg_workload_owner" {
   scope                = azurerm_resource_group.workload.id
-  principal_id         = azuread_service_principal.workload.object_id
+  principal_id         = module.user_assigned_identity.principal_id
   role_definition_name = var.role_definition_name_on_workload_rg
 }
 
@@ -9,7 +9,7 @@ resource "azurerm_role_assignment" "rg_workload_owner" {
 resource "azurerm_role_assignment" "rg_user_specified" {
   for_each             = azurerm_resource_group.user_specified
   scope                = each.value.id
-  principal_id         = azuread_service_principal.workload.object_id
+  principal_id         = module.user_assigned_identity.principal_id
   role_definition_name = var.role_definition_name_on_workload_rg
 }
 
@@ -19,7 +19,7 @@ resource "azurerm_role_assignment" "user_input" {
   scope                                  = each.value.scope
   role_definition_id                     = each.value.role_definition_id
   role_definition_name                   = each.value.role_definition_name
-  principal_id                           = each.value.assign_to_workload_principal == true ? azuread_service_principal.workload.object_id : each.value.principal_id
+  principal_id                           = each.value.assign_to_workload_principal == true ? module.user_assigned_identity.principal_id : each.value.principal_id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id

--- a/service_principal.tf
+++ b/service_principal.tf
@@ -1,4 +1,0 @@
-resource "azuread_service_principal" "workload" {
-  application_id = azuread_application.workload.application_id
-}
-

--- a/tfe.tf
+++ b/tfe.tf
@@ -14,7 +14,7 @@ module "station-tfe" {
       description = "Is true when using dynamic credentials to authenticate to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
     },
     TFC_AZURE_RUN_CLIENT_ID = {
-      value       = azuread_service_principal.workload.application_id
+      value       = module.user_assigned_identity.client_id
       category    = "env"
       description = "The client ID for the Service Principal / Application used when authenticating to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
     },

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -1,3 +1,13 @@
+module "user_assigned_identity" {
+  source              = "./user_assigned_identity"
+  name                = "mi-workload-identity"
+  resource_group_name = azurerm_resource_group.workload.name
+  location            = azurerm_resource_group.workload.location
+  tags                = local.tags
+  role_assignments    = []
+  group_membership    = []
+}
+
 module "user_assigned_identities" {
   for_each            = var.user_assigned_identities
   source              = "./user_assigned_identity/"

--- a/user_assigned_identity/outputs.tf
+++ b/user_assigned_identity/outputs.tf
@@ -1,3 +1,16 @@
-output "identities" {
-  value = azurerm_user_assigned_identity.identity
+output "id" {
+  value = azurerm_user_assigned_identity.identity.id
 }
+
+output "client_id" {
+  value = azurerm_user_assigned_identity.identity.client_id
+}
+
+output "principal_id" {
+  value = azurerm_user_assigned_identity.identity.principal_id
+}
+
+output "tenant_id" {
+  value = azurerm_user_assigned_identity.identity.tenant_id
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "environment_name" {
 
 variable "role_definition_name_on_workload_rg" {
   type        = string
-  description = "Which role to assign the workload Service Principal on the workload Resource Group"
+  description = "Which role to assign the workload principal on the workload resource group"
   default     = "Owner"
 }
 


### PR DESCRIPTION
This pull request replaces the use of `azuread_ application` and `azuread_service_principal` with a singular Managed Identity (`azurerm_user_assigned_identity`).