### PR TITLE
Add resource_group_name as an input variable

### DIFF
--- a/resource_group.tf
+++ b/resource_group.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "workload" {
-  name     = "rg-${random_id.workload.hex}-${var.environment_name}"
+  name     = var.resource_group_name == null ? "rg-${var.tfe.workspace_name}-${var.environment_name}" : "rg-${var.resource_group_name}"
   location = var.default_location
   tags     = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,16 @@ variable "environment_name" {
   default     = "dev"
 }
 
+variable "resource_group_name" {
+  type        = string
+  default     = null
+  description = <<EOF
+    (Optional) The name of the resource group to create for the workload. The final name is prefixed with `rg-`.
+
+    If a value is not provided, Station will set the name to `rg-${var.tfe.workspace_name}-${var.environment_name}`
+  EOF
+}
+
 variable "role_definition_name_on_workload_rg" {
   type        = string
   description = "Which role to assign the workload Service Principal on the workload Resource Group"

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "resource_group_name" {
   description = <<EOF
     (Optional) The name of the resource group to create for the workload. The final name is prefixed with `rg-`.
 
-    If a value is not provided, Station will set the name to `rg-${var.tfe.workspace_name}-${var.environment_name}`
+    If a value is not provided, Station will set the name to `rg-var.tfe.workspace_name-var.environment_name`
   EOF
 }
 


### PR DESCRIPTION
Relevant issue #55 

This pull request changes the default name of the resource group for the workload environment. As well as letting the user specify their RG name. Defaulting to rg-var.tfe.workspace_name-var.environment_name.