### PR TITLE
Pass `local.tags` to workload workspace (fixes #63)

### DIFF
--- a/tags.tf
+++ b/tags.tf
@@ -1,7 +1,7 @@
 locals {
   tags = merge(
     {
-      "station-id"  = random_id.workload.hex,
+      "stationId"   = random_id.workload.hex,
       "environment" = var.environment_name,
     },
     var.tags

--- a/tfe.tf
+++ b/tfe.tf
@@ -53,8 +53,16 @@ module "station-tfe" {
       hcl         = false
       sensitive   = false
     },
+    tags = {
+      value       = replace(jsonencode(local.tags), "/(\".*?\"):/", "$1 = ")
+      category    = "terraform"
+      description = "Default tags from Station Deployment"
+      hcl         = true
+      sensitive   = false
+    }
     },
     # Optionals
+    #var.tfe.module_outputs_to_workspace_var.groups ? {
     try(var.tfe.module_outputs_to_workspace_var.groups == true, false) ? {
       groups = {
         value = replace(jsonencode({ for k, v in module.ad_groups : k => {


### PR DESCRIPTION
## WHAT

- Pass `local.tags` as Terraform variable to workload Terraform Cloud workspace.
- tag `station-id` has been renamed to `stationId`

## WHY

- Consistency with tagging between Deployments and Workload is useful.
- No reason to use dash, use camel case