### PR TITLE
(breaking) Change var.group_membership type to be a map. Fixes #71

### DIFF
--- a/group_membership.tf
+++ b/group_membership.tf
@@ -1,6 +1,6 @@
 resource "azuread_group_member" "workload" {
-  for_each         = toset(var.group_membership)
-  group_object_id  = each.key
+  for_each         = var.group_membership
+  group_object_id  = each.value
   member_object_id = module.user_assigned_identity.principal_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -235,9 +235,17 @@ variable "tfe" {
 }
 
 variable "group_membership" {
-  description = "List of group object ids the workload identity should be member of"
-  default     = []
-  type        = list(string)
+  description = <<EOF
+  Map of group object ids the workload identity should be member of.
+
+  Example:
+
+  group_membership = {
+    "Kubernetes Administrators" = azuread_group.k8s_admins.object_id
+  }
+  EOF
+  default     = {}
+  type        = map(string)
 }
 
 variable "role_assignment" {


### PR DESCRIPTION
## WHAT
- Change var.group_membership from being a set to a map

## WHY

- var.group_membership would fail if the object_id passed to it was created by a module made at the same time it was referenced. This is because Terraform is unable to create the set as the values are only known at apply-time.

Fixes #71 
