### PR TITLE
Resolve deprecated argument 'application_id' in azuread_service_principal

### DIFF
--- a/app_role_assignment.tf
+++ b/app_role_assignment.tf
@@ -1,8 +1,8 @@
 data "azuread_application_published_app_ids" "well_known" {}
 
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }
 
 # Assign the workload identity the `Application.ReadWrite.OwnedBy` role so it can interact with the applications they own however they desire

--- a/application/outputs.tf
+++ b/application/outputs.tf
@@ -1,3 +1,4 @@
 output "application" {
   value = azuread_application.app
 }
+

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,5 +1,5 @@
 output "client_id" {
-  value = azuread_service_principal.workload.application_id
+  value = azuread_service_principal.workload.client_id
 }
 
 output "tenant_id" {

--- a/bootstrap/service_principal.tf
+++ b/bootstrap/service_principal.tf
@@ -1,4 +1,4 @@
 resource "azuread_service_principal" "workload" {
-  application_id = azuread_application.workload.application_id
+  client_id = azuread_application.workload.client_id
 }
 

--- a/bootstrap/tfe_variables.tf
+++ b/bootstrap/tfe_variables.tf
@@ -18,7 +18,7 @@ locals {
       category    = "env"
     },
     TFC_AZURE_RUN_CLIENT_ID = {
-      value       = azuread_service_principal.workload.application_id
+      value       = azuread_service_principal.workload.client_id
       description = "The client ID for the Service Principal / Application used when authenticating to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
       sensitive   = false
       category    = "env"

--- a/providers.tf
+++ b/providers.tf
@@ -4,27 +4,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>3.79"
     }
+
     azuread = {
       source  = "hashicorp/azuread"
       version = "~>2.45"
     }
-    tfe = {
-      source  = "hashicorp/tfe"
-      version = "~>0.48"
-    }
   }
 }
-
-provider "azurerm" {
-  # Configuration options
-  features {
-
-  }
-}
-
-provider "azuread" {
-
-}
-
-provider "tfe" {}
 

--- a/test/msgraph_service_principal.tf
+++ b/test/msgraph_service_principal.tf
@@ -1,5 +1,5 @@
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }
 

--- a/tfe.tf
+++ b/tfe.tf
@@ -78,8 +78,8 @@ module "station-tfe" {
     try(var.tfe.module_outputs_to_workspace_var.applications == true, false) ? {
       applications = {
         value = replace(jsonencode({ for k, v in module.applications : k => {
-          application_id = v.application.application_id
-          object_id      = v.application.object_id
+          client_id = v.application.client_id
+          object_id = v.application.object_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User Assigned Identities provisioned by Station"

--- a/user_assigned_identity/role_assignment.tf
+++ b/user_assigned_identity/role_assignment.tf
@@ -1,8 +1,8 @@
 data "azuread_application_published_app_ids" "well_known" {}
 
 resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
+  client_id    = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing = true
 }
 
 resource "azuread_app_role_assignment" "app_workload_roles" {


### PR DESCRIPTION
This pull request fixes #80.

**Notes**

- `tfe.tf`: line 81 - `applications` changes signature (application_id to client_id).
- `providers.tf`: file created to tell callers which providers are required