### PR TITLE
fix: reference to workspace variables

### DIFF
--- a/hashicorp/tfe/tfe_variable.tf
+++ b/hashicorp/tfe/tfe_variable.tf
@@ -5,6 +5,6 @@ resource "tfe_variable" "workload" {
   description  = each.value.description
   category     = each.value.category
   workspace_id = tfe_workspace.workload.id
-  hcl          = try(each.value.hcl, false)
-  sensitive    = try(each.value.sensitive, false)
+  hcl          = each.value.hcl
+  sensitive    = each.value.sensitive
 }

--- a/hashicorp/tfe/tfe_variable.tf
+++ b/hashicorp/tfe/tfe_variable.tf
@@ -5,6 +5,6 @@ resource "tfe_variable" "workload" {
   description  = each.value.description
   category     = each.value.category
   workspace_id = tfe_workspace.workload.id
-  hcl          = each.value.hcl == null ? false : each.value.hcl
+  hcl          = try(each.value.hcl, false)
   sensitive    = each.value.sensitive
 }

--- a/hashicorp/tfe/tfe_variable.tf
+++ b/hashicorp/tfe/tfe_variable.tf
@@ -5,6 +5,6 @@ resource "tfe_variable" "workload" {
   description  = each.value.description
   category     = each.value.category
   workspace_id = tfe_workspace.workload.id
-  hcl          = each.value.hcl
+  hcl          = each.value.hcl == null ? false : each.value.hcl
   sensitive    = each.value.sensitive
 }

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -24,7 +24,7 @@ variable "workspace_env_vars" {
     value       = string
     category    = string
     description = string
-    sensitive   = bool
+    sensitive   = optional(bool))
   }))
   default = null
 }
@@ -36,7 +36,7 @@ variable "workspace_vars" {
     category    = string
     description = string
     hcl         = bool
-    sensitive   = bool
+    sensitive   = optional(bool)
   }))
   default = null
 }

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -24,6 +24,7 @@ variable "workspace_env_vars" {
     value       = string
     category    = string
     description = string
+    sensitive   = bool
   }))
   default = null
 }

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -24,7 +24,7 @@ variable "workspace_env_vars" {
     value       = string
     category    = string
     description = string
-    sensitive   = optional(bool))
+    sensitive   = optional(bool)
   }))
   default = null
 }

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -24,7 +24,7 @@ variable "workspace_env_vars" {
     value       = string
     category    = string
     description = string
-    sensitive   = optional(bool)
+    sensitive   = optional(bool, false)
   }))
   default = null
 }
@@ -35,8 +35,8 @@ variable "workspace_vars" {
     value       = any
     category    = string
     description = string
-    hcl         = bool
-    sensitive   = optional(bool)
+    hcl         = optional(bool, false)
+    sensitive   = optional(bool, false)
   }))
   default = null
 }

--- a/tfe.tf
+++ b/tfe.tf
@@ -90,9 +90,9 @@ module "station-tfe" {
     try(var.tfe.module_outputs_to_workspace_var.user_assigned_identities == true, false) ? {
       user_assigned_identities = {
         value = replace(jsonencode({ for k, v in module.user_assigned_identities : k => {
-          id           = v.identity.id
-          client_id    = v.identity.client_id
-          principal_id = v.identity.principal_id
+          id           = v.id
+          client_id    = v.client_id
+          principal_id = v.principal_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "Applications provisioned by Station"

--- a/tfe.tf
+++ b/tfe.tf
@@ -13,21 +13,25 @@ module "station-tfe" {
       value       = true
       category    = "env"
       description = "Is true when using dynamic credentials to authenticate to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
+      sensitive   = false
     },
     TFC_AZURE_RUN_CLIENT_ID = {
       value       = module.user_assigned_identity.client_id
       category    = "env"
       description = "The client ID for the Service Principal / Application used when authenticating to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
+      sensitive   = false
     },
     ARM_SUBSCRIPTION_ID = {
       value       = data.azurerm_client_config.current.subscription_id
       category    = "env"
       description = "The Subscription ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+      sensitive   = false
     },
     ARM_TENANT_ID = {
       value       = data.azurerm_client_config.current.tenant_id
       category    = "env"
       description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+      sensitive   = false
     },
   }, )
 

--- a/tfe.tf
+++ b/tfe.tf
@@ -89,10 +89,10 @@ module "station-tfe" {
     } : {},
     try(var.tfe.module_outputs_to_workspace_var.user_assigned_identities == true, false) ? {
       user_assigned_identities = {
-        value = replace(jsonencode({ for k, identity in module.user_assigned_identities : k => {
-          id           = identity.id
-          client_id    = identity.client_id
-          principal_id = identity.principal_id
+        value = replace(jsonencode({ for k, v in module.user_assigned_identities : k => {
+          id           = v.identity.id
+          client_id    = v.identity.client_id
+          principal_id = v.identity.principal_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "Applications provisioned by Station"
@@ -102,9 +102,9 @@ module "station-tfe" {
     } : {},
     try(var.tfe.module_outputs_to_workspace_var.resource_groups == true, false) ? {
       resource_groups = {
-        value = replace(jsonencode({ for key, rg in azurerm_resource_group.user_specified : key => {
-          name     = rg.name
-          location = rg.location
+        value = replace(jsonencode({ for key, v in azurerm_resource_group.user_specified : key => {
+          name     = v.rg.name
+          location = v.rg.location
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User specified resource groups provisioned by Station"
@@ -114,10 +114,10 @@ module "station-tfe" {
     } : {},
     try(var.tfe.module_outputs_to_workspace_var.role_definitions == true, false) ? {
       role_definitions = {
-        value = replace(jsonencode({ for key, role_definition in azurerm_role_definition.user_created : key => {
-          id                          = role_definition.id
-          role_definition_id          = role_definition.role_definition_id
-          role_definition_resource_id = role_definition.role_definition_resource_id
+        value = replace(jsonencode({ for key, v in azurerm_role_definition.user_created : key => {
+          id                          = v.role_definition.id
+          role_definition_id          = v.role_definition.role_definition_id
+          role_definition_resource_id = v.role_definition.role_definition_resource_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User defined roles provisioned by Station"

--- a/tfe.tf
+++ b/tfe.tf
@@ -6,7 +6,7 @@ module "station-tfe" {
   workspace_name        = var.tfe.workspace_name
   workspace_description = var.tfe.workspace_description
   vcs_repo              = try(var.tfe.vcs_repo, null)
-  workspace_env_vars = merge(try(var.tfe.env_vars, {}), {
+  workspace_env_vars = merge(try(var.tfe.workspace_env_vars, {}), {
     # DOCS: https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud
     TFC_AZURE_PROVIDER_AUTH = {
       value       = true

--- a/tfe.tf
+++ b/tfe.tf
@@ -103,8 +103,8 @@ module "station-tfe" {
     try(var.tfe.module_outputs_to_workspace_var.resource_groups == true, false) ? {
       resource_groups = {
         value = replace(jsonencode({ for key, v in azurerm_resource_group.user_specified : key => {
-          name     = v.rg.name
-          location = v.rg.location
+          name     = v.name
+          location = v.location
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User specified resource groups provisioned by Station"
@@ -115,9 +115,9 @@ module "station-tfe" {
     try(var.tfe.module_outputs_to_workspace_var.role_definitions == true, false) ? {
       role_definitions = {
         value = replace(jsonencode({ for key, v in azurerm_role_definition.user_created : key => {
-          id                          = v.role_definition.id
-          role_definition_id          = v.role_definition.role_definition_id
-          role_definition_resource_id = v.role_definition.role_definition_resource_id
+          id                          = v.id
+          role_definition_id          = v.role_definition_id
+          role_definition_resource_id = v.role_definition_resource_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User defined roles provisioned by Station"

--- a/variables.tf
+++ b/variables.tf
@@ -242,14 +242,14 @@ variable "tfe" {
       value       = string
       category    = string
       description = string
-      sensitive   = bool
+      sensitive   = optional(bool, false)
     })))
     workspace_vars = optional(map(object({
       value       = any
       category    = string
       description = string
-      hcl         = bool
-      sensitive   = bool
+      hcl         = optional(bool, false)
+      sensitive   = optional(bool, false)
     })))
     module_outputs_to_workspace_var = optional(object({
       groups                   = optional(bool)

--- a/variables.tf
+++ b/variables.tf
@@ -231,6 +231,7 @@ variable "tfe" {
       value       = string
       category    = string
       description = string
+      sensitive   = bool
     })))
     workspace_vars = optional(map(object({
       value       = any


### PR DESCRIPTION
This pull request has multiple fixes:
- Add default values to optional types in variables in `tfe_variable`: `hcl`, `sensitive`
- `tfe.tf`:
  - fix reference to user variables
  - add `sensitive` to all default environment variables
  - use less verbose k,v names in for loop in tfe_variable creation