### PR TITLE
Revert "Updated azurerm to 3.x" and changed to 3.7+

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.8"
+      version = "~>3.79"
     }
 
     azuread = {

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.79"
+      version = "~>3.7"
     }
 
     azuread = {

--- a/test/providers.tf
+++ b/test/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.79"
+      version = "~>3.7"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
Reverts blinqas/station#107 and changes the azurerm version constraint to 3.7+ but not 4.0. 