### PR TITLE
Added missing dependency

### DIFF
--- a/applications.tf
+++ b/applications.tf
@@ -7,5 +7,7 @@ module "applications" {
     each.value.owners == null ? [] : each.value.owners,
     [module.user_assigned_identity.principal_id]
   )
-}
 
+  # This ensures that the workload identity has the correct permissions before it can be used as owner for the applications
+  depends_on = [azuread_app_role_assignment.app_workload_roles]
+}


### PR DESCRIPTION
This PR should solve issue #103. 

In short the issue is that the Terraform apply would fail if the role assignment for the user assigned identity would  happen after the creation of the application. 

Previously when running the application test ` terraform apply -target module.station-applications` it would fail most of the time, but if you ran a new Terraform apply after the one that failed it would succeed.  

After the new changes I could not reproduced the original issue :smile: 
