### PR TITLE
Added the possibility to change the name for the default workload identity

### DIFF
--- a/test/user_assigned_identities_test.tf
+++ b/test/user_assigned_identities_test.tf
@@ -7,7 +7,7 @@ module "station-uai" {
     workspace_description = "This workspace contains groups_tests from https://github.com/blinqas/station.git"
     workspace_name        = "station-tests-uai_tests"
   }
-  managed_identiy_name = "testName"
+  managed_identity_name = "testName"
   user_assigned_identities = {
     minimum = {
       name = "uai-01"

--- a/test/user_assigned_identities_test.tf
+++ b/test/user_assigned_identities_test.tf
@@ -7,7 +7,7 @@ module "station-uai" {
     workspace_description = "This workspace contains groups_tests from https://github.com/blinqas/station.git"
     workspace_name        = "station-tests-uai_tests"
   }
-
+  managed_identiy_name = "testName"
   user_assigned_identities = {
     minimum = {
       name = "uai-01"

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -1,6 +1,6 @@
 module "user_assigned_identity" {
   source               = "./user_assigned_identity"
-  name                 = "mi-workload-identity"
+  name                 = var.managed_identiy_name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : "mi-${var.managed_identiy_name}"
   resource_group_name  = azurerm_resource_group.workload.name
   location             = azurerm_resource_group.workload.location
   tags                 = local.tags

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -1,6 +1,6 @@
 module "user_assigned_identity" {
   source               = "./user_assigned_identity"
-  name                 = var.managed_identiy_name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : "mi-${var.managed_identiy_name}"
+  name                 = var.managed_identity_name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : "mi-${var.managed_identity_name}"
   resource_group_name  = azurerm_resource_group.workload.name
   location             = azurerm_resource_group.workload.location
   tags                 = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -20,9 +20,9 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "managed_identiy_name" {
+variable "managed_identity_name" {
   description = <<EOF
-    The name of the managed identity (identiy provided to the workload) that is created. The final name is prefixed with `mi-`.
+    The name of the managed identity (identity provided to the workload) that is created. The final name is prefixed with `mi-`.
 
     If a value is not provided, Station will set the name to `mi-var.tfe.workspace_name-var.environment_name`
   EOF

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "resource_group_name" {
 
 variable "managed_identiy_name" {
   description = <<EOF
-    The name of the workload identiyt that is created. The final name is prefixed with `mi-`.
+    The name of the managed identity (identiy provided to the workload) that is created. The final name is prefixed with `mi-`.
 
     If a value is not provided, Station will set the name to `mi-var.tfe.workspace_name-var.environment_name`
   EOF

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,16 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "managed_identiy_name" {
+  description = <<EOF
+    The name of the workload identiyt that is created. The final name is prefixed with `mi-`.
+
+    If a value is not provided, Station will set the name to `mi-var.tfe.workspace_name-var.environment_name`
+  EOF
+  default     = null
+  type        = string
+}
+
 variable "role_definition_name_on_workload_rg" {
   description = "The name of an in-built role to assign the workload identity on the workload resource group"
   default     = "Owner"


### PR DESCRIPTION
Previously, the name of the managed identity created with each workload was `mi-workload-identity`. This could be somewhat hard to differentiate, especially when trying to find the relationship between the managed identity and the service principal in Entra ID.

Now, users should be able to set the variable `managed_identity_name` to change the name of the manged identity. The name will be prefixed with `mi-`. So if a user set's the variable value to `my_identity`, the final name will be `mi-my_identity`

If no value for the variable is provided, the name will be `mi-${var.tfe.workspace_name}-${var.environment_name}`.

I updated the test: `user_assigned_identities_test.tf` to now define a new name for the managed identity to test that it's working as expected.

This resolves: #91
