### PR TITLE
feat(application): Added support for notes in app registrations

### DIFF
--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -7,7 +7,7 @@ resource "azuread_application" "app" {
   prevent_duplicate_names        = var.azuread_application.prevent_duplicate_names
   fallback_public_client_enabled = var.azuread_application.fallback_public_client_enabled
   notes                          = var.azuread_application.notes
-  
+
   dynamic "single_page_application" {
     for_each = var.azuread_application.single_page_application == null ? [] : [1]
 

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -7,6 +7,7 @@ resource "azuread_application" "app" {
   prevent_duplicate_names        = var.azuread_application.prevent_duplicate_names
   fallback_public_client_enabled = var.azuread_application.fallback_public_client_enabled
   notes                          = var.azuread_application.notes
+  
   dynamic "single_page_application" {
     for_each = var.azuread_application.single_page_application == null ? [] : [1]
 

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -6,7 +6,7 @@ resource "azuread_application" "app" {
   identifier_uris                = var.azuread_application.identifier_uris
   prevent_duplicate_names        = var.azuread_application.prevent_duplicate_names
   fallback_public_client_enabled = var.azuread_application.fallback_public_client_enabled
-
+  notes                          = var.azuread_application.notes
   dynamic "single_page_application" {
     for_each = var.azuread_application.single_page_application == null ? [] : [1]
 

--- a/test/application_tests.tf
+++ b/test/application_tests.tf
@@ -24,6 +24,7 @@ module "station-applications" {
       prevent_duplicate_names        = true
       fallback_public_client_enabled = true
       notes                          = "This is a test application created by Station"
+
       single_page_application = {
         redirect_uris = ["https://station-test.example/spa"]
       }

--- a/test/application_tests.tf
+++ b/test/application_tests.tf
@@ -23,7 +23,7 @@ module "station-applications" {
       group_membership_claims        = ["All"]
       prevent_duplicate_names        = true
       fallback_public_client_enabled = true
-
+      notes                          = "This is a test application created by Station"
       single_page_application = {
         redirect_uris = ["https://station-test.example/spa"]
       }

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,7 @@ variable "applications" {
     identifier_uris                = optional(list(string))
     prevent_duplicate_names        = optional(bool)
     fallback_public_client_enabled = optional(bool)
+    notes                          = optional(string) #This can be used as description for the application. 1024 character limit.
 
     single_page_application = optional(object({
       redirect_uris = optional(list(string))


### PR DESCRIPTION
Added support for adding notes to Entra ID app registrations.  This can be used to give the application a better description than just the name. This has a hard limit on 1024 characters

The `notes` property was introduced in [version 2.35.0](https://github.com/hashicorp/terraform-provider-azuread/releases/tag/v2.35.0) of the `azuread` provider. As a result, there should be no requirement for us to update the provider version in the module.

**Example**

```hcl
  applications = {
    test_app_notes = {
      display_name = "Station test: maximum"
      notes        = "This is a test application created by Station"
    }
```
![image](https://github.com/blinqas/station/assets/54621884/477c7d94-fd77-4bd1-8447-eb29d7d3b3d5)
---

The application test has been updated with the new attribute and the tests are passing :heavy_check_mark: 

