### PR TITLE
ci(lint & terraform): Updated GitHub actions and terraform version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,9 +16,9 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: hashicorp/setup-terraform@v2
+    - uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 1.5.7
+        terraform_version: "~1.7.0"
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -31,12 +31,12 @@ jobs:
     name: 🔍 Terraform Code Validation
     steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
     
         - name: Set up Terraform
-          uses: hashicorp/setup-terraform@v2
+          uses: hashicorp/setup-terraform@v3
           with:
-            terraform_version: 1.6.3
+            terraform_version: "~1.7.0"
     
         - name: terraform init station module
           run: terraform init
@@ -70,15 +70,15 @@ jobs:
             tenant-id:       ${{ secrets.AZ_TENANT_ID }}
     
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         
         - name: Append Run ID to Project Name
           run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}" >> $GITHUB_ENV
         
         - name: Set up Terraform
-          uses: hashicorp/setup-terraform@v2
+          uses: hashicorp/setup-terraform@v3
           with:
-            terraform_version: 1.6.3
+            terraform_version: "~1.7.0"
             cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
     
         - name: terraform init
@@ -107,15 +107,15 @@ jobs:
             tenant-id:       ${{ secrets.AZ_TENANT_ID }}
     
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         
         - name: Append Run ID to Project Name
           run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}" >> $GITHUB_ENV
         
         - name: Set up Terraform
-          uses: hashicorp/setup-terraform@v2
+          uses: hashicorp/setup-terraform@v3
           with:
-            terraform_version: 1.6.3
+            terraform_version: "~1.7.0"
             cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
         
         - name: terraform init

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,6 +12,7 @@ on:
       - '**/*.tf'
       - '**/*.tfvars'
       - '**/*.json'
+      - '**/*.yaml'
   workflow_dispatch:
   release:
     types: [created]
@@ -90,7 +91,7 @@ jobs:
           working-directory: test
 
   apply_and_destroy:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/trunk')
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/trunk')
     environment: E2E_testing
     needs: plan
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes warning about deprecated checkout module. 

**What has been done** 
- Updated from `checkout@v3` to `checkout@v4`.
- Updated `setup-terraform@v2` to `setup-terraform@v3`
- Changed the Terraform version for all CI operations from `1.5.7` to `1.7.x`. 
- E2E tests will now trigger on changes to yaml files and also it will trigger the same way as the plan job. 