### PR TITLE
ci(tests): Changed TFC project name used when testing

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -74,7 +74,7 @@ jobs:
           uses: actions/checkout@v4
         
         - name: Append Run ID to Project Name
-          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}" >> $GITHUB_ENV
+          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}-e2e" >> $GITHUB_ENV
         
         - name: Set up Terraform
           uses: hashicorp/setup-terraform@v3
@@ -111,7 +111,7 @@ jobs:
           uses: actions/checkout@v4
         
         - name: Append Run ID to Project Name
-          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}" >> $GITHUB_ENV
+          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}-e2e" >> $GITHUB_ENV
         
         - name: Set up Terraform
           uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/terraform_test.yaml
+++ b/.github/workflows/terraform_test.yaml
@@ -59,7 +59,7 @@ jobs:
           uses: actions/checkout@v4
         
         - name: Append Run ID to Project Name
-          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}" >> $GITHUB_ENV
+          run: echo "TF_VAR_tfc_project_name=${{ secrets.TF_VAR_TFC_PROJECT_NAME }}-${{ github.run_id }}-tests" >> $GITHUB_ENV
         
         - name: Set up Terraform
           uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
I updated the Terraform Cloud (TFC) project name to differentiate between the end-to-end (e2e) tests and those utilizing the new test framework. Previously, when executed concurrently, tests occasionally failed due to the project being previously created by either the e2e tests or the native Terraform tests. This change mitigates such conflicts, ensuring more reliable parallel test execution.