### PR TITLE
build: fix deprecated azure/login version

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -37,7 +37,7 @@ jobs:
         - name: Set up Terraform
           uses: hashicorp/setup-terraform@v3
           with:
-            terraform_version: "~1.7.0"
+            terraform_version: "~1.7.0" 
     
         - name: terraform init station module
           run: terraform init
@@ -64,7 +64,7 @@ jobs:
         TF_VAR_tfc_organization_name: ${{ secrets.TF_VAR_TFC_ORGANIZATION_NAME }}
     steps:
         - name: 'Azure: login'
-          uses: azure/login@v1
+          uses: azure/login@v2
           with:
             client-id:       ${{ secrets.AZ_CLIENT_ID }}
             subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
@@ -101,7 +101,7 @@ jobs:
         TF_VAR_tfc_organization_name: ${{ secrets.TF_VAR_TFC_ORGANIZATION_NAME }}
     steps:
         - name: 'Azure: login'
-          uses: azure/login@v1
+          uses: azure/login@v2
           with:
             client-id:       ${{ secrets.AZ_CLIENT_ID }}
             subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform_test.yaml
+++ b/.github/workflows/terraform_test.yaml
@@ -49,7 +49,7 @@ jobs:
         TF_VAR_tfc_organization_name: ${{ secrets.TF_VAR_TFC_ORGANIZATION_NAME }}
     steps:
         - name: 'Azure: login'
-          uses: azure/login@v1
+          uses: azure/login@v2
           with:
             client-id:       ${{ secrets.AZ_CLIENT_ID }}
             subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}


### PR DESCRIPTION
# Updated github actions

## Description

Updated Github action that was using a deprecated node 16 version from v1 to v2. This is the current warning that shows up when we run a workflow that uses the old version of the Azure/login action.


![image](https://github.com/blinqas/station/assets/54621884/3f903a4a-fcfe-45ce-a556-aec0a39c90eb)


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [ ] (N.A) Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [ ] (N.A) All tests are passing.
- [ ] (N.A) Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] (N.A)  I have made corresponding changes to the documentation
- [ ] (N.A) My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information
v2 of the action should not change much except upgrading the node version from 16 to v20. See release notes [here](https://github.com/Azure/login/releases/tag/v2.0.0)

---

Thank you for contributing to Station!