### PR TITLE
refactor!: remove use of azuread_client_config and azurerm_client_config

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -21,6 +21,10 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  TF_VAR_subscription_id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+  TF_VAR_tenant_id: ${{ secrets.AZ_TENANT_ID }}
+
 concurrency: 
   group: terraform-plan-apply-destroy
   cancel-in-progress: false

--- a/.github/workflows/terraform_test.yaml
+++ b/.github/workflows/terraform_test.yaml
@@ -20,6 +20,10 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  TF_VAR_subscription_id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+  TF_VAR_tenant_id: ${{ secrets.AZ_TENANT_ID }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -47,8 +51,6 @@ jobs:
     env:
         TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
         TF_VAR_tfc_organization_name: ${{ secrets.TF_VAR_TFC_ORGANIZATION_NAME }}
-        TF_VAR_subscription_id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-        TF_VAR_tenant_id: ${{ secrets.AZ_TENANT_ID }}
     steps:
         - name: 'Azure: login'
           uses: azure/login@v1

--- a/.github/workflows/terraform_test.yaml
+++ b/.github/workflows/terraform_test.yaml
@@ -47,6 +47,8 @@ jobs:
     env:
         TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
         TF_VAR_tfc_organization_name: ${{ secrets.TF_VAR_TFC_ORGANIZATION_NAME }}
+        TF_VAR_subscription_id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+        TF_VAR_tenant_id: ${{ secrets.AZ_TENANT_ID }}
     steps:
         - name: 'Azure: login'
           uses: azure/login@v1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ variables.tf
 # filename: common.tf
 module "common" {
   source              = "git::https://github.com/blinqas/station.git?ref=1.3.0"
+  tenant_id           = var.tenant_id
+  subscription_id     = var.subscription_id
   environment_name    = "prod"
   resource_group_name = "common"
   tags                = local.tags.common

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,11 +7,11 @@ output "workload_service_principal_object_id" {
 }
 
 output "tenant_id" {
-  value = data.azuread_client_config.current.tenant_id
+  value = var.tenant_id
 }
 
 output "subscription_id" {
-  value = data.azurerm_client_config.current.subscription_id
+  value = var.subscription_id
 }
 
 output "workload_resource_group_name" {

--- a/role_definitions.tf
+++ b/role_definitions.tf
@@ -3,7 +3,7 @@ resource "azurerm_role_definition" "user_created" {
   role_definition_id = each.value.role_definition_id
   name               = each.value.name
   description        = each.value.description
-  scope              = each.value.scope == null ? "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.workload.name}" : each.value.scope
+  scope              = each.value.scope == null ? "/subscriptions/${var.subscription_id}/resourceGroups/${azurerm_resource_group.workload.name}" : each.value.scope
   assignable_scopes  = each.value.assignable_scopes
   dynamic "permissions" {
     for_each = each.value.permissions == null ? [] : [1]
@@ -16,3 +16,4 @@ resource "azurerm_role_definition" "user_created" {
     }
   }
 }
+

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,0 @@
-data "azuread_client_config" "current" {}
-
-data "azurerm_client_config" "current" {}

--- a/test/README.md
+++ b/test/README.md
@@ -35,6 +35,8 @@ This folder contains all tests for the Terraform Station module. The aim is to s
     export TFE_ORGANIZATION=""
     export TF_VAR_tfc_organization_name=""
     export TF_VAR_tfc_project_name=""
+    export TF_VAR_tenant_id=""
+    export TF_VAR_subscription_id=""
     ```
 
 4. **Plan and Apply**:
@@ -69,8 +71,10 @@ When adding new features to the Station module, it's crucial to validate their f
 
 ```hcl
 module "station-new-feature" {
-  depends_on = [tfe_project.test]
-  source     = "./.."
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = ""
+  subscription_id = ""
 
   tfe = {
     project_name          = tfe_project.test.name

--- a/test/test_applications.tf
+++ b/test/test_applications.tf
@@ -1,6 +1,9 @@
 module "station-applications" {
-  depends_on = [tfe_project.test]
-  source     = "./.."
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = ""
+  subscription_id = ""
+
   tfe = {
     project_name          = tfe_project.test.name
     organization_name     = data.tfe_organization.test.name

--- a/test/test_applications.tf
+++ b/test/test_applications.tf
@@ -1,8 +1,8 @@
 module "station-applications" {
   depends_on      = [tfe_project.test]
   source          = "./.."
-  tenant_id       = ""
-  subscription_id = ""
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
 
   tfe = {
     project_name          = tfe_project.test.name

--- a/test/test_groups.tf
+++ b/test/test_groups.tf
@@ -1,6 +1,9 @@
 module "station-groups" {
-  depends_on = [tfe_project.test]
-  source     = "./.."
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+
   tfe = {
     project_name          = tfe_project.test.name
     organization_name     = data.tfe_organization.test.name

--- a/test/test_role_definitions.tf
+++ b/test/test_role_definitions.tf
@@ -1,6 +1,8 @@
 module "station_role_definitions" {
-  depends_on = [tfe_project.test]
-  source     = "./.."
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
 
   tfe = {
     project_name          = tfe_project.test.name

--- a/test/test_user_assigned_identities.tf
+++ b/test/test_user_assigned_identities.tf
@@ -1,6 +1,9 @@
 module "station-uai" {
-  depends_on = [tfe_project.test]
-  source     = "./.."
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+
   tfe = {
     project_name          = tfe_project.test.name
     organization_name     = data.tfe_organization.test.name

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -8,3 +8,13 @@ variable "tfc_project_name" {
   description = "The name of the Terraform Cloud project to create"
 }
 
+variable "tenant_id" {
+  type        = string
+  description = "(Required) The Entra ID tenant ID used by the caller."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "(Required) The Azure subscription ID used by the caller."
+}
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,8 @@ This folder contains all tests for the Terraform Station module. The aim is to s
     export TFE_ORGANIZATION=""
     export TF_VAR_tfc_organization_name=""
     export TF_VAR_tfc_project_name=""
+    export TF_VAR_tenant_id=""
+    export TF_VAR_subscription_id=""
     ```
 
 4. **Starting the tests**:

--- a/tests/setup-tfe-project/variables.tf
+++ b/tests/setup-tfe-project/variables.tf
@@ -1,9 +1,20 @@
 variable "tfc_organization_name" {
   type        = string
-  description = "The name of the Terraform Cloud organization to use"
+  description = "(Required) The name of the Terraform Cloud organization to use"
 }
 
 variable "tfc_project_name" {
   type        = string
-  description = "The name of the Terraform Cloud project to create"
+  description = "(Required) The name of the Terraform Cloud project to create"
 }
+
+variable "tenant_id" {
+  type        = string
+  description = "(Required) The Entra ID tenant ID used by the caller."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "(Required) The Azure subscription ID used by the caller."
+}
+

--- a/tfe.tf
+++ b/tfe.tf
@@ -22,13 +22,13 @@ module "station-tfe" {
       sensitive   = false
     },
     ARM_SUBSCRIPTION_ID = {
-      value       = data.azurerm_client_config.current.subscription_id
+      value       = var.subscription_id
       category    = "env"
       description = "The Subscription ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
       sensitive   = false
     },
     ARM_TENANT_ID = {
-      value       = data.azurerm_client_config.current.tenant_id
+      value       = var.tenant_id
       category    = "env"
       description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
       sensitive   = false

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "tenant_id" {
+  type        = string
+  description = "(Required) The Entra ID tenant ID used by the caller."
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "(Required) The Azure subscription ID used by the caller."
+}
+
 variable "default_location" {
   description = "The name of the default location to deploy workload resources to."
   default     = "norwayeast"


### PR DESCRIPTION
# refactor!: remove use of `azuread_client_config` and `azurerm_client_config`

## Description

This pull request optimizes the data sources a Station deployment will create. By removing usage of https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config and https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config Station no longer triggers two managed resources per Terraform Cloud workspace. 

Fixes N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

This pull request introduces a breaking change by requiring two new input variables:
- `subscription_id`
- `tenant_id`

---

Thank you for contributing to Station!