### PR TITLE
test: add always() flag to role definition deletion

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -132,6 +132,7 @@ jobs:
           working-directory: test
 
         - name: destroy role definitions
+          if: always()
           run: |
             # Deleting the two role definitions created by the test, using 
             # az cli is much faster than deleting them with Terraform for some reason.


### PR DESCRIPTION
# test: add always() flag to role definition deletion

## Description

Ensures role assignment deletion is always executed in tests

Fixes n/a

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

---

Thank you for contributing to Station!