### PR TITLE
feat: directory role assignment on workload identity and User Assigned Identities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .terraform/
 *.tfstate*
 **.tfplan**
+bootstrap/.env

--- a/test/README.md
+++ b/test/README.md
@@ -52,7 +52,7 @@ This folder contains all tests for the Terraform Station module. The aim is to s
     ```
 
 6. **Tips**
-   You can also test each module separately by running `terraform plan -target module.module_you_want_to_test`
+   You can also test each module separately by running `terraform plan -target module.module_you_want_to_test -out=plan.tfplan` and then `terraform apply plan.tfplan`.
 
 ## Testing Approach for New Features in the Station Module
 

--- a/test/test_user_assigned_identities.tf
+++ b/test/test_user_assigned_identities.tf
@@ -11,25 +11,50 @@ module "station-uai" {
     workspace_name        = "station-tests-uai_tests"
   }
   managed_identity_name = "testName"
-  user_assigned_identities = {
+
+  #Test that the default workload identity is assigned the Directory role assignment
+  directory_role_assignment = {
     minimum = {
-      name = "uai-01"
+      role_name           = "Application Administrator"
+      principal_object_id = data.azurerm_client_config.current.object_id
     }
 
-    maximum = {
-      name                 = "uai-02"
-      location             = "norwayeast"
-      app_role_assignments = ["User.Read.All"]
-      group_memberships = {
-        static = module.station-groups.groups.static.object_id
+    directory_scope = {
+      role_name           = "Application Developer"
+      principal_object_id = data.azurerm_client_config.current.object_id
+      directory_scope_id  = "/"
+    }
+
+    user_assigned_identities = {
+      minimum = {
+        name = "uai-01"
       }
-      role_assignments = {
-        subscription_reader = {
-          role_definition_name = "Reader"
-          scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+
+      maximum = {
+        name                 = "uai-02"
+        location             = "norwayeast"
+        app_role_assignments = ["User.Read.All"]
+        group_memberships = {
+          static = module.station-groups.groups.static.object_id
+        }
+        role_assignments = {
+          subscription_reader = {
+            role_definition_name = "Reader"
+            scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+          }
+        }
+        directory_role_assignment = {
+          directory_reader = {
+            role_name           = "Directory Readers"
+            principal_object_id = data.azurerm_client_config.current.object_id
+          }
         }
       }
     }
   }
 }
 
+
+resource "azuread_application" "uai-test-app" {
+  display_name = "Test Application"
+}

--- a/test/test_user_assigned_identities.tf
+++ b/test/test_user_assigned_identities.tf
@@ -25,29 +25,37 @@ module "station-uai" {
       directory_scope_id  = "/"
     }
 
-    user_assigned_identities = {
-      minimum = {
-        name = "uai-01"
-      }
+    /*  
+    app_scope = {
+      role_name      = "Cloud Device Administrator"
+      principal_object_id = data.azurerm_client_config.current.object_id
+      app_scope_id = ""
+    } */
+  }
 
-      maximum = {
-        name                 = "uai-02"
-        location             = "norwayeast"
-        app_role_assignments = ["User.Read.All"]
-        group_memberships = {
-          static = module.station-groups.groups.static.object_id
+
+  user_assigned_identities = {
+    minimum = {
+      name = "uai-01"
+    }
+
+    maximum = {
+      name                 = "uai-02"
+      location             = "norwayeast"
+      app_role_assignments = ["User.Read.All"]
+      group_memberships = {
+        static = module.station-groups.groups.static.object_id
+      }
+      role_assignments = {
+        subscription_reader = {
+          role_definition_name = "Reader"
+          scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
         }
-        role_assignments = {
-          subscription_reader = {
-            role_definition_name = "Reader"
-            scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
-          }
-        }
-        directory_role_assignment = {
-          directory_reader = {
-            role_name           = "Directory Readers"
-            principal_object_id = data.azurerm_client_config.current.object_id
-          }
+      }
+      directory_role_assignment = {
+        directory_reader = {
+          role_name           = "Directory Readers"
+          principal_object_id = data.azurerm_client_config.current.object_id
         }
       }
     }

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -1,22 +1,24 @@
 module "user_assigned_identity" {
-  source               = "./user_assigned_identity"
-  name                 = var.managed_identity_name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : "mi-${var.managed_identity_name}"
-  resource_group_name  = azurerm_resource_group.workload.name
-  location             = azurerm_resource_group.workload.location
-  tags                 = local.tags
-  role_assignments     = {}
-  app_role_assignments = []
-  group_memberships    = {}
+  source                    = "./user_assigned_identity"
+  name                      = var.managed_identity_name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : "mi-${var.managed_identity_name}"
+  resource_group_name       = azurerm_resource_group.workload.name
+  location                  = azurerm_resource_group.workload.location
+  tags                      = local.tags
+  role_assignments          = {}
+  app_role_assignments      = []
+  group_memberships         = {}
+  directory_role_assignment = var.directory_role_assignment == null ? {} : var.directory_role_assignment
 }
 
 module "user_assigned_identities" {
-  for_each             = var.user_assigned_identities
-  source               = "./user_assigned_identity/"
-  name                 = each.value.name
-  resource_group_name  = each.value.resource_group_name == null ? azurerm_resource_group.workload.name : each.value.resource_group_name
-  location             = each.value.location == null ? azurerm_resource_group.workload.location : each.value.location
-  tags                 = local.tags
-  role_assignments     = each.value.role_assignments == null ? {} : each.value.role_assignments
-  app_role_assignments = each.value.app_role_assignments == null ? [] : each.value.app_role_assignments
-  group_memberships    = each.value.group_memberships == null ? {} : each.value.group_memberships
+  for_each                  = var.user_assigned_identities
+  source                    = "./user_assigned_identity/"
+  name                      = each.value.name
+  resource_group_name       = each.value.resource_group_name == null ? azurerm_resource_group.workload.name : each.value.resource_group_name
+  location                  = each.value.location == null ? azurerm_resource_group.workload.location : each.value.location
+  tags                      = local.tags
+  role_assignments          = each.value.role_assignments == null ? {} : each.value.role_assignments
+  app_role_assignments      = each.value.app_role_assignments == null ? [] : each.value.app_role_assignments
+  group_memberships         = each.value.group_memberships == null ? {} : each.value.group_memberships
+  directory_role_assignment = each.value.directory_role_assignment == null ? {} : each.value.directory_role_assignment
 }

--- a/user_assigned_identity/directory_role_assignment.tf
+++ b/user_assigned_identity/directory_role_assignment.tf
@@ -1,0 +1,12 @@
+resource "azuread_directory_role_assignment" "roles" {
+  for_each            = var.directory_role_assignment
+  app_scope_id        = each.value.app_scope_id
+  directory_scope_id  = each.value.directory_scope_id
+  role_id             = azuread_directory_role.roles[each.key].template_id
+  principal_object_id = azurerm_user_assigned_identity.identity.principal_id
+}
+
+resource "azuread_directory_role" "roles" {
+  for_each     = var.directory_role_assignment
+  display_name = each.value.role_name
+}

--- a/user_assigned_identity/variables.tf
+++ b/user_assigned_identity/variables.tf
@@ -36,3 +36,9 @@ variable "role_assignments" {
   type        = map(any)
   default     = {}
 }
+
+variable "directory_role_assignment" {
+  description = "Azure Directory Roles to assign the Managed Identity."
+  default     = {}
+  type        = map(any)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -182,7 +182,7 @@ variable "groups" {
 
 variable "user_assigned_identities" {
   description = <<EOF
-  User Assigned Identities to create."
+  User Assigned Identities to create.
 
   Example:
 
@@ -194,6 +194,9 @@ variable "user_assigned_identities" {
       app_role_assignments    = ["IdentityRiskEvent.ReadWrite.All"]
       group_memberships = {
         "Kubernetes Administrators" = azuread_group.k8s_admins.object_id
+      }
+      directory_role_assignment = {
+        role_name                      = "Application Administrator"
       }
     }
   }
@@ -209,17 +212,24 @@ variable "user_assigned_identities" {
       scope                                  = string
       role_definition_id                     = optional(string)
       role_definition_name                   = optional(string)
+      principal_id                           = optional(string)
       assign_to_workload_principal           = optional(bool)
       condition                              = optional(string)
       condition_version                      = optional(string)
       delegated_managed_identity_resource_id = optional(string)
       description                            = optional(string)
       skip_service_principal_aad_check       = optional(bool)
-      //principal_id                           = optional(string)
     })))
     group_memberships = optional(map(string))
+    directory_role_assignment = optional(map(object({
+      role_name                      = string
+      app_scope_id                 = optional(string)
+      directory_scope_id           = optional(string)
+    })))
   }))
 }
+
+
 
 
 variable "tfe" {
@@ -285,6 +295,21 @@ variable "group_membership" {
   EOF
   default     = {}
   type        = map(string)
+}
+
+variable "directory_role_assignment" {
+  description = <<EOF
+    (Optional) Map of directory_role_assignment to create. 
+
+    - assign_to_workload_principal assigns the role to the workload identity. Can not be used with principal_id.
+  EOF
+  default     = {}
+  type = map(object({
+    role_name                      = string
+    principal_object_id          = string
+    app_scope_id                 = optional(string)
+    directory_scope_id           = optional(string)
+  }))
 }
 
 variable "role_assignment" {

--- a/variables.tf
+++ b/variables.tf
@@ -222,9 +222,9 @@ variable "user_assigned_identities" {
     })))
     group_memberships = optional(map(string))
     directory_role_assignment = optional(map(object({
-      role_name                      = string
-      app_scope_id                 = optional(string)
-      directory_scope_id           = optional(string)
+      role_name          = string
+      app_scope_id       = optional(string)
+      directory_scope_id = optional(string)
     })))
   }))
 }
@@ -305,10 +305,10 @@ variable "directory_role_assignment" {
   EOF
   default     = {}
   type = map(object({
-    role_name                      = string
-    principal_object_id          = string
-    app_scope_id                 = optional(string)
-    directory_scope_id           = optional(string)
+    role_name           = string
+    principal_object_id = string
+    app_scope_id        = optional(string)
+    directory_scope_id  = optional(string)
   }))
 }
 


### PR DESCRIPTION
# Added support for directory role assignment

## Description

This PR adds support for assigning Entra ID directory roles for both the workload identity (the user assigned identity that provisions the infrastructure) and during the creation of new user assigned identity. 

This PR resolves #104 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

- I can not get the app scope deployment to work.

---

Thank you for contributing to Station!