### PR TITLE
feat: support azuread_app_role_assignment on workload identity

### DIFF
--- a/test/test_workload_identity.tf
+++ b/test/test_workload_identity.tf
@@ -1,0 +1,17 @@
+module "station-workload-identity" {
+  depends_on      = [tfe_project.test]
+  source          = "./.."
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+
+  tfe = {
+    project_name          = tfe_project.test.name
+    organization_name     = data.tfe_organization.test.name
+    workspace_description = "This workspace contains test_workload_identity from https://github.com/blinqas/station.git"
+    workspace_name        = "station-tests-workload-identity"
+  }
+
+  managed_identity_name = "workload-identity"
+  app_role_assignments  = ["User.ReadBasic.All"]
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,22 @@ variable "managed_identity_name" {
   type        = string
 }
 
+variable "app_role_assignments" {
+  description = <<EOF
+    (Optional) A set of azuread_app_role_assignment resources to assign to the workload identity. Only built-in application roles are supported.
+
+    Example:
+    ```hcl
+    app_role_assignments = [
+      "IdentityRiskEvent.ReadWrite.All",
+      "IdentityRiskEvent.Read.All"
+    ]
+    ```
+  EOF
+  default     = []
+  type        = set(string)
+}
+
 variable "role_definition_name_on_workload_rg" {
   description = "The name of an in-built role to assign the workload identity on the workload resource group"
   default     = "Owner"
@@ -161,7 +177,11 @@ variable "applications" {
 }
 
 variable "groups" {
-  description = "Map of Entra ID (Azure AD) groups to create"
+  description = <<-EOF
+    (Optional) Map of Entra ID (Azure AD) groups to create
+    Note: The workload identity is automatically assigned the App Role "User.ReadBasic.All"
+          because being "Owner" of the group is not sufficient to add principals.
+  EOF
   default     = {}
   type = map(object({
     display_name     = string


### PR DESCRIPTION
# Support `azuread_app_role_assignment` on workload identity

## Description

This pull request adds support for Entra ID App Roles (built-in) on the workload identity. It also ensures the workload identity has permissions in the Entra ID directory to perform operations such as add on groups created with Station.

Fixes #105 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

N/A

---

Thank you for contributing to Station!