### PR TITLE
feat: added support for creating a service prinicpal for the application

### DIFF
--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -124,7 +124,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  count = var.azuread_service_principal == null ? 0 : 1
+  count                         = var.azuread_service_principal == null ? 0 : 1
   client_id                     = azuread_application.app.client_id
   account_enabled               = try(var.azuread_service_principal.account_enabled, true)
   alternative_names             = try(var.azuread_service_principal.alternative_names, [])

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -122,3 +122,34 @@ resource "azuread_application" "app" {
     }
   }
 }
+
+resource "azuread_service_principal" "sp" {
+  client_id                      = azuread_application.app.application_id
+  account_enabled                = var.azuread_service_principal.account_enabled
+  alternative_names              = var.azuread_service_principal.alternative_names
+  app_role_assignment_required   = var.azuread_service_principal.app_role_assignment_required
+  description                    = var.azuread_service_principal.description
+  login_url                      = var.azuread_service_principal.login_url
+  notes                          = var.azuread_service_principal.notes
+  notification_email_addresses   = var.azuread_service_principal.notification_email_addresses
+  owners                         = var.owners
+  preferred_single_sign_on_mode  = var.azuread_service_principal.preferred_single_sign_on_mode
+  tags                           = var.azuread_service_principal.tags
+
+  dynamic "feature_tags" {
+    for_each = var.azuread_service_principal.feature_tags == null ? [] : [var.azuread_service_principal.feature_tags]
+    content {
+      custom_single_sign_on = feature_tags.value.custom_single_sign_on
+      enterprise            = feature_tags.value.enterprise
+      gallery               = feature_tags.value.gallery
+      hide                  = feature_tags.value.hide
+    }
+  }
+
+  dynamic "saml_single_sign_on" {
+    for_each = var.azuread_service_principal.saml_single_sign_on == null ? [] : [var.azuread_service_principal.saml_single_sign_on]
+    content {
+      relay_state = saml_single_sign_on.value.relay_state
+    }
+  }
+}

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -124,17 +124,17 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  client_id                      = azuread_application.app.client_id
-  account_enabled                = try(var.azuread_service_principal.account_enabled, true)
-  alternative_names              = try(var.azuread_service_principal.alternative_names, [])
-  app_role_assignment_required   = try(var.azuread_service_principal.app_role_assignment_required, false)
-  description                    = try(var.azuread_service_principal.description, null)
-  login_url                      = try(var.azuread_service_principal.login_url, null)
-  notes                          = try(var.azuread_service_principal.notes, null)
-  notification_email_addresses   = try(var.azuread_service_principal.notification_email_addresses, [])
-  owners                         = var.owners
-  preferred_single_sign_on_mode  = try(var.azuread_service_principal.preferred_single_sign_on_mode, null)
-  tags                           = try(var.azuread_service_principal.tags, [])   #This conflicts with the "feature_tags" block below
+  client_id                     = azuread_application.app.client_id
+  account_enabled               = try(var.azuread_service_principal.account_enabled, true)
+  alternative_names             = try(var.azuread_service_principal.alternative_names, [])
+  app_role_assignment_required  = try(var.azuread_service_principal.app_role_assignment_required, false)
+  description                   = try(var.azuread_service_principal.description, null)
+  login_url                     = try(var.azuread_service_principal.login_url, null)
+  notes                         = try(var.azuread_service_principal.notes, null)
+  notification_email_addresses  = try(var.azuread_service_principal.notification_email_addresses, [])
+  owners                        = var.owners
+  preferred_single_sign_on_mode = try(var.azuread_service_principal.preferred_single_sign_on_mode, null)
+  tags                          = try(var.azuread_service_principal.tags, []) #This conflicts with the "feature_tags" block below
 
   dynamic "feature_tags" {
     for_each = try(var.azuread_service_principal.feature_tags != null, false) ? [var.azuread_service_principal.feature_tags] : []

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -124,6 +124,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
+  count = var.azuread_service_principal == null ? 0 : 1
   client_id                     = azuread_application.app.client_id
   account_enabled               = try(var.azuread_service_principal.account_enabled, true)
   alternative_names             = try(var.azuread_service_principal.alternative_names, [])

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -125,17 +125,18 @@ resource "azuread_application" "app" {
 
 resource "azuread_service_principal" "sp" {
   count                         = var.azuread_service_principal == null ? 0 : 1
+
   client_id                     = azuread_application.app.client_id
-  account_enabled               = try(var.azuread_service_principal.account_enabled, true)
-  alternative_names             = try(var.azuread_service_principal.alternative_names, [])
-  app_role_assignment_required  = try(var.azuread_service_principal.app_role_assignment_required, false)
-  description                   = try(var.azuread_service_principal.description, null)
-  login_url                     = try(var.azuread_service_principal.login_url, null)
-  notes                         = try(var.azuread_service_principal.notes, null)
-  notification_email_addresses  = try(var.azuread_service_principal.notification_email_addresses, [])
+  account_enabled               = var.azuread_service_principal.account_enabled
+  alternative_names             = var.azuread_service_principal.alternative_names
+  app_role_assignment_required  = var.azuread_service_principal.app_role_assignment_required
+  description                   = var.azuread_service_principal.description
+  login_url                     = var.azuread_service_principal.login_url
+  notes                         = var.azuread_service_principal.notes
+  notification_email_addresses  = var.azuread_service_principal.notification_email_addresses
   owners                        = var.owners
-  preferred_single_sign_on_mode = try(var.azuread_service_principal.preferred_single_sign_on_mode, null)
-  tags                          = try(var.azuread_service_principal.tags, []) #This conflicts with the "feature_tags" block below
+  preferred_single_sign_on_mode = var.azuread_service_principal.preferred_single_sign_on_mode
+  tags                          = var.azuread_service_principal.tags # This conflicts with the "feature_tags" block below
 
   dynamic "feature_tags" {
     for_each = try(var.azuread_service_principal.feature_tags != null, false) ? [var.azuread_service_principal.feature_tags] : []

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -124,32 +124,33 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  client_id                      = azuread_application.app.application_id
-  account_enabled                = var.azuread_service_principal.account_enabled
-  alternative_names              = var.azuread_service_principal.alternative_names
-  app_role_assignment_required   = var.azuread_service_principal.app_role_assignment_required
-  description                    = var.azuread_service_principal.description
-  login_url                      = var.azuread_service_principal.login_url
-  notes                          = var.azuread_service_principal.notes
-  notification_email_addresses   = var.azuread_service_principal.notification_email_addresses
+  client_id                      = azuread_application.app.client_id
+  account_enabled                = try(var.azuread_service_principal.account_enabled, true)
+  alternative_names              = try(var.azuread_service_principal.alternative_names, [])
+  app_role_assignment_required   = try(var.azuread_service_principal.app_role_assignment_required, false)
+  description                    = try(var.azuread_service_principal.description, null)
+  login_url                      = try(var.azuread_service_principal.login_url, null)
+  notes                          = try(var.azuread_service_principal.notes, null)
+  notification_email_addresses   = try(var.azuread_service_principal.notification_email_addresses, [])
   owners                         = var.owners
-  preferred_single_sign_on_mode  = var.azuread_service_principal.preferred_single_sign_on_mode
-  tags                           = var.azuread_service_principal.tags
+  preferred_single_sign_on_mode  = try(var.azuread_service_principal.preferred_single_sign_on_mode, null)
+  tags                           = try(var.azuread_service_principal.tags, [])   #This conflicts with the "feature_tags" block below
 
   dynamic "feature_tags" {
-    for_each = var.azuread_service_principal.feature_tags == null ? [] : [var.azuread_service_principal.feature_tags]
+    for_each = try(var.azuread_service_principal.feature_tags != null, false) ? [var.azuread_service_principal.feature_tags] : []
     content {
-      custom_single_sign_on = feature_tags.value.custom_single_sign_on
-      enterprise            = feature_tags.value.enterprise
-      gallery               = feature_tags.value.gallery
-      hide                  = feature_tags.value.hide
+      custom_single_sign_on = try(feature_tags.value.custom_single_sign_on, false)
+      enterprise            = try(feature_tags.value.enterprise, false)
+      gallery               = try(feature_tags.value.gallery, false)
+      hide                  = try(feature_tags.value.hide, false)
     }
   }
 
   dynamic "saml_single_sign_on" {
-    for_each = var.azuread_service_principal.saml_single_sign_on == null ? [] : [var.azuread_service_principal.saml_single_sign_on]
+    for_each = try(var.azuread_service_principal.saml_single_sign_on != null, false) ? [var.azuread_service_principal.saml_single_sign_on] : []
     content {
-      relay_state = saml_single_sign_on.value.relay_state
+      relay_state = try(saml_single_sign_on.value.relay_state, "")
     }
   }
 }
+

--- a/application/azuread_application.tf
+++ b/application/azuread_application.tf
@@ -124,7 +124,7 @@ resource "azuread_application" "app" {
 }
 
 resource "azuread_service_principal" "sp" {
-  count                         = var.azuread_service_principal == null ? 0 : 1
+  count = var.azuread_service_principal == null ? 0 : 1
 
   client_id                     = azuread_application.app.client_id
   account_enabled               = var.azuread_service_principal.account_enabled

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -8,32 +8,9 @@ variable "azuread_application" {
 }
 
 variable "azuread_service_principal" {
-  type        = optional(object({
-      account_enabled                = optional(bool, true)
-      alternative_names              = optional(list(string))
-      app_role_assignment_required   = optional(bool, false)
-      description                    = optional(string)
-      login_url                      = optional(string)
-      notes                          = optional(string)
-      notification_email_addresses   = optional(list(string))
-      owners                         = optional(list(string))
-      preferred_single_sign_on_mode  = optional(string)
-      tags                           = optional(list(string))
-      use_existing                   = optional(bool, false)
-
-      feature_tags = optional(object({
-        custom_single_sign_on = optional(bool, false)
-        enterprise            = optional(bool, false)
-        gallery               = optional(bool, false)
-        hide                  = optional(bool, false)
-      }))
-
-      saml_single_sign_on = optional(object({
-        relay_state = optional(string)
-      }))
-    }))
+  type = any
   description = <<EOF
-  The configuration for the azuread_service_principal to create.
+  The configuration for the azuread_service_principal to create. See Station's applications variable on how to configure the service principal block. 
   EOF
 }
 variable "owners" {

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -7,6 +7,35 @@ variable "azuread_application" {
   EOF
 }
 
+variable "azuread_service_principal" {
+  type        = optional(object({
+      account_enabled                = optional(bool, true)
+      alternative_names              = optional(list(string))
+      app_role_assignment_required   = optional(bool, false)
+      description                    = optional(string)
+      login_url                      = optional(string)
+      notes                          = optional(string)
+      notification_email_addresses   = optional(list(string))
+      owners                         = optional(list(string))
+      preferred_single_sign_on_mode  = optional(string)
+      tags                           = optional(list(string))
+      use_existing                   = optional(bool, false)
+
+      feature_tags = optional(object({
+        custom_single_sign_on = optional(bool, false)
+        enterprise            = optional(bool, false)
+        gallery               = optional(bool, false)
+        hide                  = optional(bool, false)
+      }))
+
+      saml_single_sign_on = optional(object({
+        relay_state = optional(string)
+      }))
+    }))
+  description = <<EOF
+  The configuration for the azuread_service_principal to create.
+  EOF
+}
 variable "owners" {
   type        = set(string)
   default     = null

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -8,7 +8,7 @@ variable "azuread_application" {
 }
 
 variable "azuread_service_principal" {
-  type = any
+  type        = any
   description = <<EOF
   The configuration for the azuread_service_principal to create. See Station's applications variable on how to configure the service principal block. 
   EOF

--- a/applications.tf
+++ b/applications.tf
@@ -7,7 +7,7 @@ module "applications" {
     each.value.owners == null ? [] : each.value.owners,
     [module.user_assigned_identity.principal_id]
   )
-  azuread_service_principal = each.value.service_principal
+  azuread_service_principal = try(each.value.service_principal, null)
 
   # This ensures that the workload identity has the correct permissions before it can be used as owner for the applications
   depends_on = [azuread_app_role_assignment.app_workload_roles]

--- a/applications.tf
+++ b/applications.tf
@@ -7,7 +7,7 @@ module "applications" {
     each.value.owners == null ? [] : each.value.owners,
     [module.user_assigned_identity.principal_id]
   )
-  azuread_service_principal = try(each.value.service_principal, {})
+  azuread_service_principal = each.value.service_principal
 
   # This ensures that the workload identity has the correct permissions before it can be used as owner for the applications
   depends_on = [azuread_app_role_assignment.app_workload_roles]

--- a/applications.tf
+++ b/applications.tf
@@ -7,6 +7,7 @@ module "applications" {
     each.value.owners == null ? [] : each.value.owners,
     [module.user_assigned_identity.principal_id]
   )
+  azuread_service_principal = try(each.value.service_principal, {})
 
   # This ensures that the workload identity has the correct permissions before it can be used as owner for the applications
   depends_on = [azuread_app_role_assignment.app_workload_roles]

--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@ This folder contains all tests for the Terraform Station module. The aim is to s
 
 1. **Terraform Cloud (TFC) Project Creation**: The process begins by creating a TFC project. This project's name should match the value set in the `TF_VAR_tfc_project_name` environment variable. It's recommended to use a name like `station-tests`.
 
-2. **Workspace and Resource Creation**: For each test (files ending with `_test.tf`), a new workspace is created, and the defined Azure and/or Entra ID resources are provisioned.
+2. **Workspace and Resource Creation**: For each test (files starting with `test_.tf`), a new workspace is created, and the defined Azure and/or Entra ID resources are provisioned.
 
 ## Prerequisites
 

--- a/test/test_applications.tf
+++ b/test/test_applications.tf
@@ -106,7 +106,7 @@ module "station-applications" {
         owners                        = [data.azuread_client_config.current.object_id]
         preferred_single_sign_on_mode = "saml"
         #tags                          = ["tag1", "tag2"] #This confliencts with the "feature_tags" block below
-        use_existing                  = false
+        use_existing = false
 
         feature_tags = {
           custom_single_sign_on = true

--- a/test/test_applications.tf
+++ b/test/test_applications.tf
@@ -94,7 +94,33 @@ module "station-applications" {
           access_token_issuance_enabled = true
         }
       }
+
+      service_principal = {
+        account_enabled               = true
+        alternative_names             = ["alt_name1", "alt_name2"]
+        app_role_assignment_required  = false
+        description                   = "Service Principal for Station Test: Maximum"
+        login_url                     = "http://localhost/login"
+        notes                         = "Notes for Service Principal"
+        notification_email_addresses  = ["admin@example.com"]
+        owners                        = [data.azuread_client_config.current.object_id]
+        preferred_single_sign_on_mode = "saml"
+        #tags                          = ["tag1", "tag2"] #This confliencts with the "feature_tags" block below
+        use_existing                  = false
+
+        feature_tags = {
+          custom_single_sign_on = true
+          enterprise            = true
+          gallery               = false
+          hide                  = false
+        }
+
+        saml_single_sign_on = {
+          relay_state = "/relay"
+        }
+      }
     }
+
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,31 @@ variable "applications" {
         id_token_issuance_enabled     = optional(bool)
       }))
     }))
+
+    service_principal = optional(object({
+      account_enabled               = optional(bool, true)
+      alternative_names             = optional(list(string))
+      app_role_assignment_required  = optional(bool, false)
+      description                   = optional(string)
+      login_url                     = optional(string)
+      notes                         = optional(string)
+      notification_email_addresses  = optional(list(string))
+      owners                        = optional(list(string))
+      preferred_single_sign_on_mode = optional(string)
+      tags                          = optional(list(string))
+      use_existing                  = optional(bool, false)
+
+      feature_tags = optional(object({
+        custom_single_sign_on = optional(bool, false)
+        enterprise            = optional(bool, false)
+        gallery               = optional(bool, false)
+        hide                  = optional(bool, false)
+      }))
+
+      saml_single_sign_on = optional(object({
+        relay_state = optional(string)
+      }))
+    }))
   }))
 }
 


### PR DESCRIPTION
# Added support for optionally creating a service principal when creating an application

## Description

This should give us the option to create a service principal (Enterprise application) in the `applications` block

Fixes #136 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

---

Thank you for contributing to Station!