### PR TITLE
feat(boostrap): added support for newer provider versions and improved bootstrap process 

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -27,8 +27,14 @@ Demoing Station is also very fast now!
 **IMPORTANT!** Do not run scripts from the internet without understanding what they do.
 
 ### Before you begin:
-1. **Update the Bootstrap Script**:  
+1. **Ensure you have the correct permissions**
+   - Your entra ID account should be global admin 
+   - You will need to have the owner on all the subscriptions you want to use with station
+   - You will to have access to an [Organization token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-tokens) or a [Team token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-tokens) in Terrafrom Cloud
+   - You will need to create a Github PAT that has access to create new reposiotories in the target Github Organization
+2. **Update the Bootstrap Script**:  
    Update the bootstrap script with your own values. Carefully read the variable names and comments to enter the correct values.
+  
 
 #### Environment Variables you need to set in the script
 

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -28,10 +28,10 @@ Demoing Station is also very fast now!
 
 ### Before you begin:
 1. **Ensure you have the correct permissions**
-   - Your entra ID account should be global admin 
-   - You will need to have the owner on all the subscriptions you want to use with station
-   - You will to have access to an [Organization token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-tokens) or a [Team token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-tokens) in Terrafrom Cloud
-   - You will need to create a Github PAT that has access to create new reposiotories in the target Github Organization
+   - Your entraID account should have the role `Global Administrator` active. 
+   - You will need to have the RBAC role `Owner` on all the subscriptions you want to use with station.
+   - You will to have access to an [Organization token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-tokens) or a [Team token](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-tokens) in Terrafrom Cloud.
+   - You will need to create a Github PAT that has access to create new reposiotories in the target Github Organization.
 2. **Update the Bootstrap Script**:  
    Update the bootstrap script with your own values. Carefully read the variable names and comments to enter the correct values.
   

--- a/bootstrap/application.tf
+++ b/bootstrap/application.tf
@@ -1,5 +1,5 @@
 resource "azuread_application" "workload" {
-  display_name = "station-deployments"
+  display_name = var.station_entraID_application_name
   notes        = "This application is used to create new workloads using the station module"
 }
 

--- a/bootstrap/application.tf
+++ b/bootstrap/application.tf
@@ -1,6 +1,6 @@
 resource "azuread_application" "workload" {
-  display_name = "app-station-bootstrap"
-  notes        = "This application tests Station TFE tests (github.com/kimfy/Station.git) from TFC to Azure"
+  display_name = "station-deployments"
+  notes        = "This application is used to create new workloads using the station module"
 }
 
 

--- a/bootstrap/application.tf
+++ b/bootstrap/application.tf
@@ -1,5 +1,5 @@
 resource "azuread_application" "workload" {
-  display_name = var.station_entraID_application_name
+  display_name = var.entraID_application_name
   notes        = "This application is used to create new workloads using the station module"
 }
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -22,7 +22,7 @@ export TF_VAR_vcs_repo_owner=$GITHUB_OWNER   # Set repository owner from above v
 export ARM_SUBSCRIPTION_ID="Subscription_1"  # Azure Subscription ID for the provider. Here you can use the subscription_1 from TF_VAR_subscription_ids.
 
 # Optional variables that can be used to customize resource names
-#export TF_VAR_station_entraID_application_name = "station-deployments"     # Application name for the Entrada ID application that will create the new workloads in Azure.
+#export TF_VAR_entraID_application_name = "station-deployments"     # Application name for the Entrada ID application that will create the new workloads in Azure.
 #export TF_VAR_vcs_repo_name="station-deployments"                          # Overrides the default Github Repository Name.
 #export TF_VAR_tfc_project_name="station"                                   # Project name in Terraform Cloud for 'station'.
 #export TF_VAR_deployments_tfc_workspace_name="station-deployments"         # TFC Workspace for station deployments.

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -19,8 +19,8 @@ export TF_VAR_tfc_token="YourTFCToken"                                  # Token 
 export GITHUB_OWNER="Github-username-or-org"                # Target GitHub username or organization for the provider.
 export GITHUB_TOKEN=$TF_VAR_vcs_repo_PAT                    # Authentication token for GitHub provider.
 export TF_VAR_vcs_repo_owner=$GITHUB_OWNER                  # Set repository owner from above variable.
-export TF_VAR_vcs_repo_name="station-deployments_test"      # Default repository name (can be overridden in variables.tf).
-
+export TF_VAR_vcs_repo_name="station-deployments"           # Default repository name (can be overridden in variables.tf).
+export ARM_SUBSCRIPTION_ID="Subscription_1"                 # Azure Subscription ID for the provider. Here you can use the subscription_1 from TF_VAR_subscription_ids. 
 
 # Color definitions
 RED='\033[31m'
@@ -89,7 +89,7 @@ rm -rf ./.terraform
 
 cp "./providers/providers_local_state.tf" "./providers.tf"
 
-terraform init -upgrade
+terraform init
 
 terraform plan -out "./plan.tfplan"
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,26 +1,31 @@
 #!/bin/bash
 
 # Terraform Cloud (TFC) Authentication details
-export TF_CLOUD_ORGANIZATION="your-org"                      # Organization name in Terraform Cloud.
-export TF_WORKSPACE="station-bootstrap"                      # Workspace for storing the bootstrap state.
+export TF_CLOUD_ORGANIZATION="your-org" # Organization name in Terraform Cloud.
+export TF_WORKSPACE="station-bootstrap" # Workspace for storing the bootstrap state.
 
 # Terraform-specific variables
-export TF_VAR_tfc_organization_name=$TF_CLOUD_ORGANIZATION   # Set organization name from above variable.
-export TF_VAR_bootstrap_tfc_workspace_name=$TF_WORKSPACE     # Set workspace name from above variable.
-export TF_VAR_tfc_project_name="station"                     # Project name in Terraform Cloud for 'station'.
-export TF_VAR_deployments_tfc_workspace_name="station-deployments"    # Workspace for station deployments.
-export TF_VAR_vcs_repo_github_app_installation_id="ghain-yourKey"     # ID for GitHub app installation in TFC. Ensure GitHub Terraform app is pre-installed: https://app.terraform.io/api/v2/github-app/installations.
-# export TF_VAR_vcs_repo_oauth_token_id=""                   # Alternative to GitHub app installation ID. Use either this or the above.
+export TF_VAR_tfc_organization_name=$TF_CLOUD_ORGANIZATION                  # Set organization name from above variable.
+export TF_VAR_bootstrap_tfc_workspace_name=$TF_WORKSPACE                    # Set workspace name from above variable.
+export TF_VAR_vcs_repo_github_app_installation_id="ghain-yourKey"           # ID for GitHub app installation in TFC. Ensure GitHub Terraform app is pre-installed in your org: https://app.terraform.io/api/v2/github-app/installations.
+# export TF_VAR_vcs_repo_oauth_token_id=""                                  # Alternative to GitHub app installation ID. Use either this or the above.
 export TF_VAR_subscription_ids="[\"Subscription_1\"], [\"Subscription_2\"]" # Azure Subscriptions where Station should have owner permissions. Fetch using: az account list --query "[?tenantId=='yourTenantID'].{Name:name, ID:id}" --output table
-export TF_VAR_vcs_repo_PAT="ghp_GithubPersonalAccessToken"  # Personal Access Token (PAT) for TFC to create repositories. Documentation: https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-export TF_VAR_tfc_token="YourTFCToken"                                  # Token for Terraform Cloud, can be a team or organization token. https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens
+export TF_VAR_vcs_repo_PAT="ghp_GithubPersonalAccessToken"                  # Personal Access Token (PAT) for TFC to create repositories. Documentation: https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
+export TF_VAR_tfc_token="YourTFCToken"                                      # Token for Terraform Cloud, can be a team or organization token. https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens
 
-# GitHub-related variables
-export GITHUB_OWNER="Github-username-or-org"                # Target GitHub username or organization for the provider.
-export GITHUB_TOKEN=$TF_VAR_vcs_repo_PAT                    # Authentication token for GitHub provider.
-export TF_VAR_vcs_repo_owner=$GITHUB_OWNER                  # Set repository owner from above variable.
-export TF_VAR_vcs_repo_name="station-deployments"           # Default repository name (can be overridden in variables.tf).
-export ARM_SUBSCRIPTION_ID="Subscription_1"                 # Azure Subscription ID for the provider. Here you can use the subscription_1 from TF_VAR_subscription_ids. 
+# GitHub Authentication details
+export GITHUB_OWNER="Github-username-or-org" # Target GitHub username or organization for the provider.
+export GITHUB_TOKEN=$TF_VAR_vcs_repo_PAT     # Authentication token for GitHub provider.
+export TF_VAR_vcs_repo_owner=$GITHUB_OWNER   # Set repository owner from above variable.
+
+# Azure-specific variables
+export ARM_SUBSCRIPTION_ID="Subscription_1"  # Azure Subscription ID for the provider. Here you can use the subscription_1 from TF_VAR_subscription_ids.
+
+# Optional variables that can be used to customize resource names
+#export TF_VAR_station_entraID_application_name = "station-deployments"     # Application name for the Entrada ID application that will create the new workloads in Azure.
+#export TF_VAR_vcs_repo_name="station-deployments"                          # Overrides the default Github Repository Name.
+#export TF_VAR_tfc_project_name="station"                                   # Project name in Terraform Cloud for 'station'.
+#export TF_VAR_deployments_tfc_workspace_name="station-deployments"         # TFC Workspace for station deployments.
 
 # Color definitions
 RED='\033[31m'
@@ -29,7 +34,7 @@ YELLOW='\033[33m'
 BLUE='\033[34m'
 RESET='\033[0m'
 
-# Validation to ensure you're not trying to bootstrap into the wrong Azure tenant 
+# Validation to ensure you're not trying to bootstrap into the wrong Azure tenant
 echo -e "${GREEN}Starting the bootstrap process against this tenant:${RESET} \n \n "
 
 TENANT_ID=$(az account show --query "tenantId" -o tsv)
@@ -48,13 +53,12 @@ SUBSCRIPTION_IDS_CLEANED=$(echo $TF_VAR_subscription_ids | sed 's/\\//g')
 echo -e "${YELLOW}Selected Azure subscription(s):${RESET} ${GREEN}$SUBSCRIPTION_IDS_CLEANED${RESET}"
 
 # Splitting the values and querying Azure for each
-IFS=',' read -ra SUBSCRIPTIONS <<< "$SUBSCRIPTION_IDS_CLEANED"
+IFS=',' read -ra SUBSCRIPTIONS <<<"$SUBSCRIPTION_IDS_CLEANED"
 for sub in "${SUBSCRIPTIONS[@]}"; do
     SUB_CLEAN=$(echo $sub | tr -d '[]" ')
     echo -en " \n ${YELLOW} Details for subscription ID $SUB_CLEAN: ${RESET}"
     az account show --subscription $SUB_CLEAN | jq '. | {tenantId, name, user}'
 done
-
 
 # Display environment variables to the user
 echo -e "\n${YELLOW}Environment Variables:${RESET}"
@@ -66,12 +70,11 @@ echo -e "${BLUE}TF_VAR_deployments_tfc_workspace_name:${RESET} ${GREEN}$TF_VAR_d
 echo -e "${BLUE}TF_VAR_vcs_repo_github_app_installation_id:${RESET} ${GREEN}$TF_VAR_vcs_repo_github_app_installation_id${RESET}"
 echo -e "${BLUE}TF_VAR_subscription_ids:${RESET} ${GREEN}$TF_VAR_subscription_ids${RESET}"
 echo -e "${BLUE}TF_VAR_vcs_repo_PAT:${RESET} ${GREEN}[hidden for security]${RESET}"
-echo -e "${BLUE}TF_VAR_tfc_token:${RESET} ${GREEN}[hidden for security]${RESET}" 
+echo -e "${BLUE}TF_VAR_tfc_token:${RESET} ${GREEN}[hidden for security]${RESET}"
 echo -e "${BLUE}GITHUB_OWNER:${RESET} ${GREEN}$GITHUB_OWNER${RESET}"
-echo -e "${BLUE}GITHUB_TOKEN:${RESET} ${GREEN}[hidden for security]${RESET}" 
+echo -e "${BLUE}GITHUB_TOKEN:${RESET} ${GREEN}[hidden for security]${RESET}"
 echo -e "${BLUE}TF_VAR_vcs_repo_owner:${RESET} ${GREEN}$TF_VAR_vcs_repo_owner${RESET}"
 echo -e "${BLUE}TF_VAR_vcs_repo_name:${RESET} ${GREEN}$TF_VAR_vcs_repo_name${RESET}"
-
 
 ### Prompt the user if they want to continue###
 echo -e " \n Do you want to proceed with the above settings? [y/n]"
@@ -80,7 +83,6 @@ read -p "" answer
 [[ $answer =~ ^[Yy] ]] || exit
 
 echo "${GREEN}Starting the bootstrap!${RESET}"
-
 
 rm ./providers.tf
 rm -rf ./terraform.tfstate.d

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -9,7 +9,7 @@ export TF_VAR_tfc_organization_name=$TF_CLOUD_ORGANIZATION                  # Se
 export TF_VAR_bootstrap_tfc_workspace_name=$TF_WORKSPACE                    # Set workspace name from above variable.
 export TF_VAR_vcs_repo_github_app_installation_id="ghain-yourKey"           # ID for GitHub app installation in TFC. Ensure GitHub Terraform app is pre-installed in your org: https://app.terraform.io/api/v2/github-app/installations.
 # export TF_VAR_vcs_repo_oauth_token_id=""                                  # Alternative to GitHub app installation ID. Use either this or the above.
-export TF_VAR_subscription_ids="[\"Subscription_1\"], [\"Subscription_2\"]" # Azure Subscriptions where Station should have owner permissions. Fetch using: az account list --query "[?tenantId=='yourTenantID'].{Name:name, ID:id}" --output table
+export TF_VAR_subscription_ids='[\"Subscription_1\", \"Subscription_2\"]'   # Azure Subscriptions where Station should have owner permissions. Fetch using: az account list --query "[?tenantId=='yourTenantID'].{Name:name, ID:id}" --output table
 export TF_VAR_vcs_repo_PAT="ghp_GithubPersonalAccessToken"                  # Personal Access Token (PAT) for TFC to create repositories. Documentation: https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 export TF_VAR_tfc_token="YourTFCToken"                                      # Token for Terraform Cloud, can be a team or organization token. https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens
 
@@ -48,16 +48,16 @@ echo -e "${YELLOW}Azure Account Information:${RESET}"
 az account show | jq '. | {tenantId, name, user}'
 
 # Removing the escaping and converting to a single array
-SUBSCRIPTION_IDS_CLEANED=$(echo $TF_VAR_subscription_ids | sed 's/\\//g')
+SUBSCRIPTION_IDS_CLEANED="${TF_VAR_subscription_ids//\\/}"
 
 echo -e "${YELLOW}Selected Azure subscription(s):${RESET} ${GREEN}$SUBSCRIPTION_IDS_CLEANED${RESET}"
 
 # Splitting the values and querying Azure for each
 IFS=',' read -ra SUBSCRIPTIONS <<<"$SUBSCRIPTION_IDS_CLEANED"
 for sub in "${SUBSCRIPTIONS[@]}"; do
-    SUB_CLEAN=$(echo $sub | tr -d '[]" ')
+    SUB_CLEAN=$(echo "$sub" | tr -d '[]" ')
     echo -en " \n ${YELLOW} Details for subscription ID $SUB_CLEAN: ${RESET}"
-    az account show --subscription $SUB_CLEAN | jq '. | {tenantId, name, user}'
+    az account show --subscription "$SUB_CLEAN" | jq '. | {tenantId, name, user}'
 done
 
 # Display environment variables to the user
@@ -78,7 +78,7 @@ echo -e "${BLUE}TF_VAR_vcs_repo_name:${RESET} ${GREEN}$TF_VAR_vcs_repo_name${RES
 
 ### Prompt the user if they want to continue###
 echo -e " \n Do you want to proceed with the above settings? [y/n]"
-read -p "" answer
+read -rp "" answer
 
 [[ $answer =~ ^[Yy] ]] || exit
 

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -22,10 +22,11 @@ export TF_VAR_vcs_repo_owner=$GITHUB_OWNER   # Set repository owner from above v
 export ARM_SUBSCRIPTION_ID="Subscription_1"  # Azure Subscription ID for the provider. Here you can use the subscription_1 from TF_VAR_subscription_ids.
 
 # Optional variables that can be used to customize resource names
-#export TF_VAR_entraID_application_name = "station-deployments"     # Application name for the Entrada ID application that will create the new workloads in Azure.
-#export TF_VAR_vcs_repo_name="station-deployments"                          # Overrides the default Github Repository Name.
-#export TF_VAR_tfc_project_name="station"                                   # Project name in Terraform Cloud for 'station'.
-#export TF_VAR_deployments_tfc_workspace_name="station-deployments"         # TFC Workspace for station deployments.
+export TF_VAR_entraID_application_name = "station-deployments"             # Application name for the Entrada ID application that will create the new workloads in Azure.
+export TF_VAR_tfc_project_name="station"                                   # Project name in Terraform Cloud for 'station'.
+export TF_VAR_deployments_tfc_workspace_name="station-deployments"         # TFC Workspace for station deployments.
+export TF_VAR_vcs_repo_name="station-deployments"                          # Overrides the default Github Repository Name.
+
 
 # Color definitions
 RED='\033[31m'

--- a/bootstrap/providers/providers.tf
+++ b/bootstrap/providers/providers.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.49"
+      version = "~> 4.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.36"
+      version = "~> 3.0"
     }
 
     tfe = {
@@ -17,7 +17,7 @@ terraform {
 
     github = {
       source  = "integrations/github"
-      version = "~> 5.38"
+      version = "~> 6.0"
     }
   }
 

--- a/bootstrap/providers/providers_local_state.tf
+++ b/bootstrap/providers/providers_local_state.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.8, < 5"
+      version = "~> 4.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.36"
+      version = "~> 3.0"
     }
 
     tfe = {
@@ -16,7 +16,7 @@ terraform {
     }
     github = {
       source  = "integrations/github"
-      version = "~> 5.38"
+      version = "~> 6.0"
     }
   }
 }

--- a/bootstrap/role_assignment.tf
+++ b/bootstrap/role_assignment.tf
@@ -3,7 +3,6 @@ data "azurerm_subscription" "deployment" {
   subscription_id = each.key
 }
 
-
 resource "azurerm_role_assignment" "station_subscription_owner" {
   for_each             = data.azurerm_subscription.deployment
   scope                = each.value.id

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -5,7 +5,8 @@ variable "tfc_organization_name" {
 
 variable "tfc_project_name" {
   type        = string
-  description = "The name of a Terraform Cloud project. Provisioned on initial bootstrap run."
+  description = "(Optional) The name of a Terraform Cloud project. Provisioned on initial bootstrap run."
+  default     = "station"
 }
 
 variable "tfc_token" {
@@ -20,7 +21,8 @@ variable "bootstrap_tfc_workspace_name" {
 
 variable "deployments_tfc_workspace_name" {
   type        = string
-  description = "The name of a single Terraform Cloud workspace for Station Deployments."
+  description = "(Optional) The name of a single Terraform Cloud workspace for Station Deployments."
+  default     = "station-deployments"
 }
 
 variable "tfc_hostname" {
@@ -37,7 +39,8 @@ variable "bootstrap_repo_url" {
 
 variable "vcs_repo_name" {
   type        = string
-  description = "The name you want to give the repository that should hold you Station deployments"
+  description = "(Optional) The name you want to give the repository that should hold you Station deployments"
+  default     = "station-deployments"
 }
 
 variable "vcs_repo_branch" {
@@ -60,7 +63,7 @@ variable "vcs_repo_github_app_installation_id" {
 
 variable "vcs_repo_tags_regex" {
   type        = string
-  description = "Optional) A regular expression used to trigger a Workspace run for matching Git tags. This option conflicts with trigger_patterns and trigger_prefixes. Should only set this value if the former is not being used."
+  description = "(Optional) A regular expression used to trigger a Workspace run for matching Git tags. This option conflicts with trigger_patterns and trigger_prefixes. Should only set this value if the former is not being used."
   default     = null
 }
 
@@ -81,4 +84,11 @@ variable "subscription_ids" {
   type        = set(string)
   description = "Set of Subscription ID's the Station identity can manage."
   default     = []
+}
+
+variable "station_entraID_application_name" {
+  type        = string
+  description = "The name of the Azure AD application that will be created for Station. This application will be used to create new workloads using the station module."
+  default     = "station-deployments"
+
 }

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -86,7 +86,7 @@ variable "subscription_ids" {
   default     = []
 }
 
-variable "station_entraID_application_name" {
+variable "entraID_application_name" {
   type        = string
   description = "The name of the Azure AD application that will be created for Station. This application will be used to create new workloads using the station module."
   default     = "station-deployments"


### PR DESCRIPTION
## Description

- This upgrades the azurerm(v3 to v4), azuread(v2 to v3) and github (v5 to v6) providers to the newest version
- Fixes the issue with having to provide the subscription_id when running the bootstrap script https://github.com/blinqas/station/issues/173 
- Changed the name of the stations EntraID application and associated sp. Users also now have to option to specify a custom name.
- Changed some of the TF variables to have a default value. This should reduce the amount of variables users have to edit in the bootstrap script.
- Updated the docs with that permission you need to bootstrap station

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [ ] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [ ] All tests are passing.
- [ ] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

---

Thank you for contributing to Station!