### PR TITLE
fix: removed provider config block

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -17,8 +17,3 @@ terraform {
     }
   }
 }
-provider "azurerm" {
-  features {
-
-  }
-}


### PR DESCRIPTION
## Description

During the last release, I accidentally added the provider configuration block directly to the module while migrating the tests. Since provider configurations should be defined outside of modules, this change now marks the module as a legacy module.

Legacy modules cannot be used with `for_each`, `count`, or `depends_on`. 

```hcl
│ Error: Module is incompatible with count, for_each, and depends_on
│ 
│   on k8s.tf line 10, in module "k8s":
│   10:   for_each            = local.aks_common_config
│ 
│ The module at module.k8s is a legacy module which contains its own local provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments.
```
This PR reverts the changes done to the provider file.
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [ ] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [ ] All tests are passing.
- [ ] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

---

Thank you for contributing to Station!