### PR TITLE
fix: properly handle movement of Terraform resources in between v10 and v12

### DIFF
--- a/role_assignment.tf
+++ b/role_assignment.tf
@@ -1,7 +1,7 @@
 # Assign the Landing Zone identity Owner on this Landing Zone's resource groups
 moved {
   from = azurerm_role_assignment.rg_workload_owner
-  to   = azurerm_role_assignment.lz_owner
+  to   = azurerm_role_assignment.lz_owner["default"]
 }
 
 resource "azurerm_role_assignment" "lz_owner" {

--- a/role_assignment.tf
+++ b/role_assignment.tf
@@ -12,6 +12,11 @@ resource "azurerm_role_assignment" "lz_owner" {
   principal_type       = "ServicePrincipal"
 }
 
+moved {
+  from = azurerm_role_assignment.user_input
+  to   = azurerm_role_assignment.lz_identity
+}
+
 // Role Assignments for the Landing Zone identity (via var.identity.role_assignments)
 resource "azurerm_role_assignment" "lz_identity" {
   for_each                               = local.role_assignments_merged

--- a/role_assignment.tf
+++ b/role_assignment.tf
@@ -4,6 +4,11 @@ moved {
   to   = azurerm_role_assignment.lz_owner["default"]
 }
 
+moved {
+  from = azurerm_role_assignment.rg_user_specified
+  to   = azurerm_role_assignment.lz_owner
+}
+
 resource "azurerm_role_assignment" "lz_owner" {
   for_each             = merge({ default = azurerm_resource_group.workload }, azurerm_resource_group.user_specified)
   scope                = each.value.id

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -30,7 +30,7 @@ locals {
 
 moved {
   from = azuread_app_role_assignment.app_workload_roles
-  to   = user_assigned_identity.azuread_app_role_assignment.this["Application.ReadWrite.OwnedBy"]
+  to   = module.user_assigned_identity.azuread_app_role_assignment.this["Application.ReadWrite.OwnedBy"]
 }
 
 module "user_assigned_identity" {

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -7,7 +7,7 @@ locals {
   */
   required_app_roles = merge(
     // Ensure Managed Identity has required permissions to read basic user information when the caller wants to create Entra ID Groups. Having only "Owner" on the group is not sufficient (even though the Terraform Provider docs says so).
-    var.groups == {} ? {} : {
+    length(var.groups) == 0 ? {} : {
       "User.ReadBasic.All" = {
         app_role_id        = data.azuread_service_principal.msgraph.app_role_ids["User.ReadBasic.All"]
         resource_object_id = data.azuread_service_principal.msgraph.object_id
@@ -19,7 +19,7 @@ locals {
     },
 
     # When `var.applications` is specified, ensure the Landing Zone Identity have the correct permissions so it can manage it in their landing zone configuration.
-    var.applications == {} ? {} : {
+    length(var.applications) == 0 ? {} : {
       "Application.ReadWrite.OwnedBy" = {
         app_role_id        = data.azuread_service_principal.msgraph.app_role_ids["Application.ReadWrite.OwnedBy"]
         resource_object_id = data.azuread_service_principal.msgraph.object_id

--- a/user_assigned_identities.tf
+++ b/user_assigned_identities.tf
@@ -28,6 +28,11 @@ locals {
   )
 }
 
+moved {
+  from = azuread_app_role_assignment.app_workload_roles
+  to   = user_assigned_identity.azuread_app_role_assignment.this["Application.ReadWrite.OwnedBy"]
+}
+
 module "user_assigned_identity" {
   name                       = var.identity.name == null ? "mi-${var.tfe.workspace_name}-${var.environment_name}" : var.identity.name
   source                     = "./user_assigned_identity"


### PR DESCRIPTION
# Properly handle movement of Terraform resources in between v10 and v12

## Description
Use `moved` to properly role assignments being moved to new ways of provisioning. See issue below for exact issues.

This PR also fixes an issue where every Landing Zone identity deployed with Station was given three App Roles which are only needed when you define `var.applications` or `var.groups`.

Fixes #194

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.