### PR TITLE
feat: adds support for global environment variable sets

### DIFF
--- a/bootstrap/files/README.md
+++ b/bootstrap/files/README.md
@@ -1,0 +1,2 @@
+# alz-applications
+Terraform Configuration for Application Landing Zones

--- a/bootstrap/files/data.tf
+++ b/bootstrap/files/data.tf
@@ -1,0 +1,5 @@
+data "tfe_project" "alz" {
+  name = "Azure Application Landing Zones"
+}
+
+data "azurerm_client_config" "current" {}

--- a/bootstrap/files/github_repositories.tf
+++ b/bootstrap/files/github_repositories.tf
@@ -1,0 +1,30 @@
+resource "github_repository" "this" {
+  for_each     = local.repositories
+  name         = each.value.name
+  description  = each.value.description
+  visibility   = try(each.value.visibility, "private")
+  has_wiki     = try(each.value.has_wiki, false)
+  auto_init    = try(each.value.auto_init, true)
+  has_issues   = true
+  has_projects = try(each.value.has_projects, true)
+  template {
+    owner                = var.github_owner
+    repository           = "gh-template-station-workload"
+    include_all_branches = false
+  }
+}
+resource "github_branch_default" "default" {
+  for_each   = github_repository.this
+  repository = each.value.name
+  branch     = "trunk"
+}
+
+locals {
+  repositories = {
+    common = {
+      name         = "common"
+      description  = "Terraform configuration for Common resources"
+      has_projects = true
+    }
+  }
+}

--- a/bootstrap/files/locals.tf
+++ b/bootstrap/files/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  vcs_repo = {
+    for k, v in github_repository.this : k => {
+      identifier                 = v.full_name
+      branch                     = "trunk"
+      github_app_installation_id = var.vcs_repo_github_app_installation_id
+    }
+  }
+}

--- a/bootstrap/files/providers.tf
+++ b/bootstrap/files/providers.tf
@@ -17,7 +17,7 @@ terraform {
       version = "~>0.65"
     }
   }
-   cloud {}
+  cloud {}
 }
 
 provider "azurerm" {

--- a/bootstrap/files/providers.tf
+++ b/bootstrap/files/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~>2.45"
+      version = "~>3.0"
     }
     github = {
       source  = "integrations/github"
@@ -17,24 +17,22 @@ terraform {
       version = "~>0.65"
     }
   }
-  cloud {}
+  # cloud {}
 }
 
 provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 provider "github" {
-  owner = var.config.github.owner
+  owner = var.github_owner
   app_auth {
-    id              = var.config.github.provider.id
-    installation_id = var.config.github.provider.installation_id
+    id              = var.github_app_id
+    installation_id = var.github_app_installation_id
     pem_file        = base64decode(var.github_app_pem_file)
   }
 }
 
-provider "tfe" {
-  organization = var.config.terraform_cloud.organization_name
-  token        = var.tfe_token
-}
-
+provider "tfe" {}

--- a/bootstrap/files/providers.tf
+++ b/bootstrap/files/providers.tf
@@ -17,7 +17,7 @@ terraform {
       version = "~>0.65"
     }
   }
-  # cloud {}
+   cloud {}
 }
 
 provider "azurerm" {

--- a/bootstrap/github.tf
+++ b/bootstrap/github.tf
@@ -1,3 +1,13 @@
+resource "null_resource" "fork_template_repo" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      which gh >/dev/null 2>&1 || exit 1
+      gh repo view ${var.config.github.owner}/gh-template-station-workload >/dev/null 2>&1 || \
+      gh repo fork https://github.com/blinqas/gh-template-station-workload.git --org ${var.config.github.owner} --clone=false
+    EOT
+    when    = create
+  }
+}
 resource "github_repository" "this" {
   name        = var.config.github.repository
   description = var.config.github.description
@@ -32,7 +42,10 @@ resource "github_repository_file" "bootstrap" {
 resource "github_repository_file" "alz_applications" {
   for_each = toset([
     "providers.tf",
-    "variables.tf"
+    "variables.tf",
+    "github_repositories.tf",
+    "data.tf",
+    "locals.tf"
   ])
   file                = each.value
   content             = file("${path.root}/files/${each.value}")

--- a/hashicorp/tfe/tfe_variable.tf
+++ b/hashicorp/tfe/tfe_variable.tf
@@ -14,6 +14,23 @@ data "tfe_variables" "workload" {
   depends_on   = [tfe_variable.workload]
 }
 
+resource "tfe_variable_set" "global" {
+  name         = "Global Environment Variables"
+  description  = "Common environment variables for all workspaces"
+  organization = var.organization_name
+  global       = true
+}
+
+resource "tfe_variable" "global" {
+  for_each        = var.global_vars
+  key             = each.key
+  value           = each.value.value
+  description     = each.value.description
+  category        = each.value.category
+  variable_set_id = tfe_variable_set.global.id
+  hcl             = try(each.value.hcl, false)
+  sensitive       = try(each.value.sensitive, false)
+}
 
 locals {
   #Restructure the output so it's possible to create terraform tests

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -39,7 +39,7 @@ variable "workspace_vars" {
   default = null
 }
 variable "global_vars" {
-  description = "Map of variables to provision on the workspace in Terraform Cloud"
+  description = "Map of variables defined at the organization level, shared across all workspaces."
   type = map(object({
     value       = any
     category    = string

--- a/hashicorp/tfe/variables.tf
+++ b/hashicorp/tfe/variables.tf
@@ -38,6 +38,17 @@ variable "workspace_vars" {
   }))
   default = null
 }
+variable "global_vars" {
+  description = "Map of variables to provision on the workspace in Terraform Cloud"
+  type = map(object({
+    value       = any
+    category    = string
+    description = string
+    hcl         = optional(bool, false)
+    sensitive   = optional(bool, false)
+  }))
+  default = null
+}
 
 variable "vcs_repo" {
   description = "Settings for the workspace's VCS repository, enabling the UI/VCS-driven run workflow."

--- a/tfe.tf
+++ b/tfe.tf
@@ -8,8 +8,7 @@ module "station-tfe" {
   workspace_settings    = try(var.tfe.workspace_settings, null)
   vcs_repo              = try(var.tfe.vcs_repo, null)
   file_triggers_enabled = try(var.tfe.vcs_repo.tags_regex, null) == null ? true : false # if tags_regex is supplied, set to false, this removes an uneccessary step
-  workspace_vars = merge(try(var.tfe.workspace_vars, {}), {
-    # Terraform variables are prefixed with TF_VAR_ to suppress TFC Runner warning of unused variables.
+  global_vars = merge(try(var.tfe.global_vars, {}), {
     station_id = {
       value       = random_id.workload.hex
       category    = "terraform"
@@ -17,6 +16,21 @@ module "station-tfe" {
       hcl         = false
       sensitive   = false
     },
+    ARM_SUBSCRIPTION_ID = {
+      value       = var.subscription_id
+      category    = "env"
+      description = "The Subscription ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+      sensitive   = false
+    },
+    ARM_TENANT_ID = {
+      value       = var.tenant_id
+      category    = "env"
+      description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
+      sensitive   = false
+    }
+    }
+  )
+  workspace_vars = merge(try(var.tfe.workspace_vars, {}), {
     workload_resource_group_name = {
       value       = azurerm_resource_group.workload.name
       category    = "terraform"
@@ -42,18 +56,7 @@ module "station-tfe" {
       description = "The client ID for the Service Principal / Application used when authenticating to Azure. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-terraform-cloud"
       sensitive   = false
     },
-    ARM_SUBSCRIPTION_ID = {
-      value       = var.subscription_id
-      category    = "env"
-      description = "The Subscription ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
-      sensitive   = false
-    },
-    ARM_TENANT_ID = {
-      value       = var.tenant_id
-      category    = "env"
-      description = "The Azure Tenant ID to connect to. https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration#configure-the-azurerm-or-azuread-provider"
-      sensitive   = false
-    }
+
     },
     try(length(module.ad_groups) > 0) ? {
       groups = {


### PR DESCRIPTION
# Add global environment variable sets and automate workload setup

## Description

This adds global environment variable sets that are available throughout the entire Terraform organization. It also automates the forking of the template repository into the new organization and automates the setup of the necessary files for creating workloads in `alz-applications`.

## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Other

## Testing

See the testing [docs](../tests/readme.md) for more information about how to test your code  
- [x] Performed a local `terraform plan` and `apply` in a test org
- [ ] All tests are passing.  
- [ ] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings. I have run `terraform validate` in the root module and all sub modules where I have made changes
