### PR TITLE
feat(tfe): add application_id field to the var.application outputed to the lz

### DIFF
--- a/tests/tfe.tftest.hcl
+++ b/tests/tfe.tftest.hcl
@@ -266,6 +266,18 @@ run "tfe_outputs_to_workspace_variables" {
   }
 
   assert {
+    # We have to parse the hcl string to get the variable as a terraform object 
+    condition     = jsondecode(replace(module.station-tfe.workspace_variables.applications.value, "/(\\\"[^\"]+\\\") =/", "$1:"))["minimum_tfe_test"].application_id != null
+    error_message = "The application application_id is null"
+  }
+
+  assert {
+    # Verify that application_id has the /applications/ prefix
+    condition     = startswith(jsondecode(replace(module.station-tfe.workspace_variables.applications.value, "/(\\\"[^\"]+\\\") =/", "$1:"))["minimum_tfe_test"].application_id, "/applications/")
+    error_message = "The application application_id does not start with /applications/"
+  }
+
+  assert {
     condition     = module.station-tfe.workspace_variables.applications.hcl == true
     error_message = "The application workspace variable is not of type hcl"
   }

--- a/tfe.tf
+++ b/tfe.tf
@@ -70,11 +70,11 @@ module "station-tfe" {
     try(length(module.applications) > 0) ? {
       applications = {
         value = replace(jsonencode({ for k, v in module.applications : k => {
-          id           = v.application.id
-          display_name = v.application.display_name
-          client_id    = v.application.client_id
+          id             = v.application.id
+          display_name   = v.application.display_name
+          client_id      = v.application.client_id
           application_id = "/applications/${v.application.client_id}"
-          object_id    = v.application.object_id
+          object_id      = v.application.object_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"
         description = "User Assigned Identities provisioned by Station"

--- a/tfe.tf
+++ b/tfe.tf
@@ -73,6 +73,7 @@ module "station-tfe" {
           id           = v.application.id
           display_name = v.application.display_name
           client_id    = v.application.client_id
+          application_id = "/applications/${v.application.client_id}"
           object_id    = v.application.object_id
         } }), "/(\".*?\"):/", "$1 = ") # Credit: https://brendanthompson.com/til/2021/03/hcl-enabled-tfe-variables
         category    = "terraform"


### PR DESCRIPTION
## Description

Add new `application_id` field to TFE workspace variables that includes the `/applications/` prefix, allowing users to reference it directly without manual string formatting.

This is a non-breaking change as the original `id` and `client_id` fields remain unchanged.

**Before this change:**
```terraform
resource "azuread_application_password" "example" {
  application_id = "/applications/${var.applications["example"].client_id}"
}
```

**After this change:**
```terraform
resource "azuread_application_password" "example" {
  application_id = var.applications["example"].application_id
}
```

Fixes #221 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing docs for more information about how to test your code 
- [x] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [x] All tests are passing.
- [x] Added, updated, or removed tests when appropriate

### Test Changes
- Added assertions to verify `application_id` field exists in TFE workspace variables
- Added assertion to verify `application_id` has the correct `/applications/` prefix format using `startswith()`
- Updated `tests/tfe.tftest.hcl` to validate the new field structure

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

The new `application_id` field is added alongside the existing `id` and `client_id` fields to maintain backward compatibility. Users can continue using the original fields or adopt the new `application_id` field for cleaner code when working with Azure AD application resources.

---

Thank you for contributing to Station!
