### PR TITLE
fix: rename parent_id to user_assigned_identity_id in federated credential

### DIFF
--- a/application_federated_identity_credential.tf
+++ b/application_federated_identity_credential.tf
@@ -10,11 +10,11 @@ locals {
 }
 
 resource "azurerm_federated_identity_credential" "oidc-tfe" {
-  for_each  = local.oidc_tfe
-  parent_id = module.user_assigned_identity.id
-  name      = "terraform-cloud-run-phase-${each.value.phase}"
-  audience  = ["api://AzureADTokenExchange"]
-  issuer    = "https://app.terraform.io"
-  subject   = "organization:${var.tfe.organization_name}:project:${var.tfe.project.name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
+  for_each                  = local.oidc_tfe
+  user_assigned_identity_id = module.user_assigned_identity.id
+  name                      = "terraform-cloud-run-phase-${each.value.phase}"
+  audience                  = ["api://AzureADTokenExchange"]
+  issuer                    = "https://app.terraform.io"
+  subject                   = "organization:${var.tfe.organization_name}:project:${var.tfe.project.name}:workspace:${var.tfe.workspace_name}:run_phase:${each.value.phase}"
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "~>4.15"
+      version               = "~>4.65"
       configuration_aliases = [azurerm.connectivity]
     }
 


### PR DESCRIPTION
## Description

Resolves deprecation warning from AzureRM Provider,  parent_id on azurerm_federated_identity_credential is removed in v5.0. 

Fixes #248 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Testing
See the testing [docs](../tests/readme.md) for more information about how to test your code 
- [ ] Performed a local `terraform plan`, `apply`, and `destroy` to validate changes.
- [ ] All tests are passing.
- [ ] Added, updated, or removed tests when appropriate

## Checklist

Before submitting this PR, please ensure the following:

- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style guide
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings. I have ran `terraform validate` in the root module and all sub modules where I have made changes

## Additional Information

Provide any additional information or context about the pull request here.

---

Thank you for contributing to Station!